### PR TITLE
docs: add OpenPrecedent validation setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,20 @@ npx vitest run -t "exports a template pack"  # run a single test by name
 npm run dev            # tsc --watch
 ```
 
+## OpenPrecedent Validation
+
+This repository is currently being used as a real-project validation target for OpenPrecedent.
+
+Before starting a new Codex session for active validation work, read:
+
+- `docs/validation/openprecedent-validation-context.md`
+- `docs/validation/current-issue-state.md`
+- `docs/validation/runtime-setup.md`
+- `docs/validation/codex-session-start-prompt.md`
+
+Use a shared `OPENPRECEDENT_HOME` so runtime lineage history is reused across sessions.
+Treat those validation docs as the local execution layer for this repository.
+
 ## Architecture
 
 ```
@@ -52,3 +66,4 @@ Tests are in `test/e2e.test.ts` — a single file that tests the core modules di
 - File paths use `node:path` and `node:fs` — no third-party fs utilities
 - Archive handling uses the `tar` npm package
 - Import paths in source use `.js` extensions (ESM convention)
+- Keep work issue-scoped when running the OpenPrecedent validation flow

--- a/docs/validation/codex-session-start-prompt.md
+++ b/docs/validation/codex-session-start-prompt.md
@@ -1,0 +1,42 @@
+# Codex Session Start Prompt
+
+Use this prompt when starting a new Codex session for the active OpenPrecedent validation work in ClawPack.
+
+## Prompt
+
+You are working in `/workspace/02-projects/active/clawpack`.
+
+This repository is currently a real-project validation target for OpenPrecedent.
+
+Your active task is:
+
+- add manifest-level harness metadata so a `.clawpack` package describes a reusable agent runtime environment rather than only a file bundle
+
+Before doing any work, read:
+
+- `AGENTS.md`
+- `docs/validation/openprecedent-validation-context.md`
+- `docs/validation/current-issue-state.md`
+- `docs/validation/runtime-setup.md`
+- `docs/validation/todo.md`
+
+Operating rules:
+
+- work only on the active issue
+- keep scope narrow
+- do not introduce generic platform abstractions unless directly required
+- use OpenPrecedent as a runtime decision-lineage aid during execution
+- record durable examples when lineage changes or confirms a decision
+
+Before making edits, perform one lineage query for `initial_planning`.
+
+Use additional lineage queries only at:
+
+- `before_file_write`
+- `after_failure`
+
+Your first output should be:
+
+1. a short summary of the current task
+2. the immediate plan
+3. whether lineage context appears needed before code changes

--- a/docs/validation/current-issue-state.md
+++ b/docs/validation/current-issue-state.md
@@ -1,0 +1,38 @@
+# Current Issue State
+
+## Active Goal
+
+Use ClawPack as the first real external project for validating OpenPrecedent decision-lineage reuse and harness transfer during live Codex development.
+
+## Current Product Position
+
+ClawPack should be treated as an agent harness packaging tool.
+It packages reusable agent runtime environments, not only one OpenClaw-specific bundle format.
+
+## Current Constraints
+
+- keep the work issue-scoped
+- do not introduce generic platform abstractions unless the chosen task requires them
+- use OpenPrecedent during execution, not only for post-hoc analysis
+- transfer only a minimal harness set at first
+- prefer one real feature task over infrastructure-only changes
+
+## What Has Already Been Decided
+
+- OpenPrecedent owns the main research plan and final validation report
+- ClawPack owns the local execution documents for new Codex sessions
+- all Codex sessions should share `OPENPRECEDENT_HOME=$HOME/.openprecedent/runtime`
+- lineage queries should be used at `initial_planning`, `before_file_write`, and `after_failure`
+
+## Next Actions
+
+1. align ClawPack docs and local instructions with the validation setup
+2. implement the first real feature task: add manifest-level harness metadata that makes a package describe a reusable agent runtime environment
+3. run that task with OpenPrecedent lineage queries enabled
+4. record concrete examples where lineage changed or confirmed a decision
+
+## Not In Scope Right Now
+
+- generic runtime SDK design
+- hosted multi-user architecture
+- broad process migration beyond the minimal harness set

--- a/docs/validation/openprecedent-validation-context.md
+++ b/docs/validation/openprecedent-validation-context.md
@@ -1,0 +1,29 @@
+# OpenPrecedent Validation Context
+
+## Why This Exists
+
+ClawPack is being used as the first real external project for validating OpenPrecedent runtime decision-lineage reuse and harness transfer.
+
+This repository does not own the master research plan.
+The research framing lives in OpenPrecedent:
+
+- [clawpack-real-project-validation-plan.md](/workspace/02-projects/incubation/openprecedent/docs/engineering/clawpack-real-project-validation-plan.md)
+
+This directory only contains the local execution context needed for work inside ClawPack.
+
+## What ClawPack Is Testing
+
+ClawPack is currently serving three validation goals:
+
+1. test whether OpenPrecedent lineage helps real development decisions in a new repository
+2. test whether harness practices developed in OpenPrecedent transfer cleanly into a new project
+3. sharpen ClawPack's product framing as an agent harness packaging tool rather than a narrow OpenClaw packaging utility
+
+## Local Operating Rule
+
+Inside ClawPack, prefer the narrowest setup that keeps new Codex sessions aligned:
+
+- read the local validation docs first
+- use a shared `OPENPRECEDENT_HOME`
+- work on one issue at a time
+- query lineage only when prior precedent may materially affect direction

--- a/docs/validation/runtime-setup.md
+++ b/docs/validation/runtime-setup.md
@@ -1,0 +1,36 @@
+# Runtime Setup
+
+## Shared OpenPrecedent Home
+
+Use one stable runtime home across all Codex sessions:
+
+```bash
+export OPENPRECEDENT_HOME="$HOME/.openprecedent/runtime"
+```
+
+This keeps runtime lineage history, invocation logs, and shared context in one place across sessions.
+
+## Recommended Startup Check
+
+Run:
+
+```bash
+export OPENPRECEDENT_HOME="$HOME/.openprecedent/runtime"
+echo "$OPENPRECEDENT_HOME"
+```
+
+If you want a shell with the variable already set, use:
+
+```bash
+./scripts/dev-with-openprecedent.sh bash
+```
+
+## Query Timing
+
+Use the OpenPrecedent workflow when prior judgment may materially affect direction:
+
+- `initial_planning`
+- `before_file_write`
+- `after_failure`
+
+Do not query on every turn.

--- a/docs/validation/todo.md
+++ b/docs/validation/todo.md
@@ -1,0 +1,20 @@
+# Validation Todo
+
+## Immediate Setup
+
+- confirm the local validation docs are still aligned with the OpenPrecedent-side research plan
+- keep `OPENPRECEDENT_HOME` fixed across all Codex sessions
+- start each new session by reading the local validation docs before editing
+
+## First Product Work
+
+- implement manifest-level harness metadata for `.clawpack`
+- make the manifest describe agent runtime environment intent, not only exported files
+- prefer naming and schema choices that clarify ClawPack as an agent harness packaging tool
+- avoid infrastructure-only setup tasks as the only validation activity
+
+## Evidence Capture
+
+- note when lineage changes task framing, constraints, or recovery decisions
+- note when lineage confirms an intended direction
+- preserve durable examples for the OpenPrecedent validation report

--- a/scripts/dev-with-openprecedent.sh
+++ b/scripts/dev-with-openprecedent.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export OPENPRECEDENT_HOME="${OPENPRECEDENT_HOME:-$HOME/.openprecedent/runtime}"
+echo "OPENPRECEDENT_HOME=$OPENPRECEDENT_HOME"
+
+exec "$@"


### PR DESCRIPTION
## Summary
- add repository-local OpenPrecedent validation context and session startup docs
- update AGENTS.md with the validation workflow entry points
- add a helper script to launch shells with shared OPENPRECEDENT_HOME

## Testing
- not run (docs and helper script only)