### PR TITLE
feat: add harness metadata to manifest

### DIFF
--- a/src/core/packer.ts
+++ b/src/core/packer.ts
@@ -3,7 +3,15 @@ import path from "node:path";
 import crypto from "node:crypto";
 import * as tar from "tar";
 import JSON5 from "json5";
-import type { Manifest, PackType, SensitiveFlags, RiskLevel, WorkspaceBinding } from "./types.js";
+import type {
+  HarnessComponent,
+  HarnessMetadata,
+  Manifest,
+  PackType,
+  RiskLevel,
+  SensitiveFlags,
+  WorkspaceBinding,
+} from "./types.js";
 import { SCHEMA_VERSION } from "./types.js";
 import { inspect, resolveStateDir, findConfigFile, resolveWorkspaceBindings } from "./scanner.js";
 
@@ -175,6 +183,40 @@ function classifyPath(relPath: string): string {
   return path.join("state", relPath);
 }
 
+function hasIncludedPath(includedPaths: readonly string[], pattern: RegExp): boolean {
+  return includedPaths.some((includedPath) => pattern.test(includedPath));
+}
+
+function deriveHarnessComponents(includedPaths: readonly string[], configPath: string | null): HarnessComponent[] {
+  const componentChecks: Array<[HarnessComponent, boolean]> = [
+    ["workspace", hasIncludedPath(includedPaths, /^workspace(?:-[^/]+)?\//)],
+    ["config", Boolean(configPath)],
+    ["skills", hasIncludedPath(includedPaths, /^workspace(?:-[^/]+)?\/skills\//)],
+    ["agents", hasIncludedPath(includedPaths, /^agents\//)],
+    ["credentials", hasIncludedPath(includedPaths, /^credentials\//) || hasIncludedPath(includedPaths, /^agents\/[^/]+\/agent\/auth-profiles\.json$/)],
+    ["sessions", hasIncludedPath(includedPaths, /^agents\/[^/]+\/sessions\//) || hasIncludedPath(includedPaths, /^sessions-[^/]+\.(json|json5)$/)],
+    ["memory", hasIncludedPath(includedPaths, /^memory\//) || hasIncludedPath(includedPaths, /^[^/]+\.(db|sqlite|lance)$/)],
+    ["cron", hasIncludedPath(includedPaths, /^cron\//)],
+    ["hooks", hasIncludedPath(includedPaths, /^hooks\//)],
+    ["extensions", hasIncludedPath(includedPaths, /^extensions\//)],
+    ["logs", hasIncludedPath(includedPaths, /^logs\//)],
+    ["browser", hasIncludedPath(includedPaths, /^browser\//)],
+    ["completions", hasIncludedPath(includedPaths, /^completions\//)],
+  ];
+
+  return componentChecks
+    .filter(([, present]) => present)
+    .map(([component]) => component);
+}
+
+function createHarnessMetadata(includedPaths: readonly string[], configPath: string | null, targetProduct: string): HarnessMetadata {
+  return {
+    intent: "agent-runtime-environment",
+    targetProduct,
+    components: deriveHarnessComponents(includedPaths, configPath),
+  };
+}
+
 interface ExportOptions {
   sourcePath?: string;
   outputPath?: string;
@@ -253,6 +295,7 @@ export async function exportPack(options: ExportOptions): Promise<ExportResult> 
     packType,
     packId: generatePackId(),
     createdAt: new Date().toISOString(),
+    harness: createHarnessMetadata(includedPaths, configPath, inspectResult.product),
     source: {
       product: "openclaw",
       version: inspectResult.version || "unknown",
@@ -371,6 +414,12 @@ export async function importPack(options: ImportOptions): Promise<ImportResult> 
     const parsedManifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as Partial<Manifest>;
     const manifest: Manifest = {
       ...parsedManifest,
+      harness: parsedManifest.harness ?? createHarnessMetadata(
+        Array.isArray(parsedManifest.includedPaths) ? parsedManifest.includedPaths : [],
+        parsedManifest.source?.configPath ? parsedManifest.source.configPath : null,
+        parsedManifest.source?.product ?? "openclaw"
+      ),
+      includedPaths: Array.isArray(parsedManifest.includedPaths) ? parsedManifest.includedPaths : [],
       workspaces: Array.isArray(parsedManifest.workspaces) ? parsedManifest.workspaces : [],
     } as Manifest;
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,4 +1,4 @@
-export const SCHEMA_VERSION = "0.3.0";
+export const SCHEMA_VERSION = "0.4.0";
 
 export type PackType = "template" | "instance";
 
@@ -11,6 +11,7 @@ export interface Manifest {
   packType: PackType;
   packId: string;
   createdAt: string;
+  harness: HarnessMetadata;
   source: {
     product: string;
     version: string;
@@ -20,6 +21,29 @@ export interface Manifest {
   workspaces: WorkspaceBinding[];
   sensitiveFlags: SensitiveFlags;
   riskLevel: RiskLevel;
+}
+
+export type HarnessIntent = "agent-runtime-environment";
+
+export type HarnessComponent =
+  | "workspace"
+  | "config"
+  | "skills"
+  | "agents"
+  | "credentials"
+  | "sessions"
+  | "memory"
+  | "cron"
+  | "hooks"
+  | "extensions"
+  | "logs"
+  | "browser"
+  | "completions";
+
+export interface HarnessMetadata {
+  intent: HarnessIntent;
+  targetProduct: string;
+  components: HarnessComponent[];
 }
 
 export interface WorkspaceBinding {

--- a/src/core/verifier.ts
+++ b/src/core/verifier.ts
@@ -148,6 +148,21 @@ export function verify(targetDir: string, manifest?: Manifest): VerifyResult {
       message: `Pack type: ${manifest.packType}`,
     });
 
+    const hasHarnessMetadata =
+      manifest.harness?.intent === "agent-runtime-environment" &&
+      typeof manifest.harness?.targetProduct === "string" &&
+      manifest.harness.targetProduct.length > 0;
+    checks.push({
+      name: "manifest_harness",
+      passed: hasHarnessMetadata,
+      message: hasHarnessMetadata
+        ? `Harness intent: ${manifest.harness.intent} for ${manifest.harness.targetProduct}`
+        : "Manifest harness metadata missing or invalid",
+    });
+    if (!hasHarnessMetadata) {
+      warnings.push("Pack manifest does not describe a reusable agent runtime environment");
+    }
+
     if (manifestWorkspaces.length > 0) {
       const missingWorkspace = manifestWorkspaces.find((workspace) => {
         const logicalPath = workspace.isDefault ? "workspace" : workspace.logicalPath;

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -249,6 +249,9 @@ describe("export + import", () => {
     expect(result.outputFile).toBe(outputFile);
     expect(result.manifest.packType).toBe("template");
     expect(result.manifest.riskLevel).toBe("safe-share");
+    expect(result.manifest.harness.intent).toBe("agent-runtime-environment");
+    expect(result.manifest.harness.targetProduct).toBe("openclaw");
+    expect(result.manifest.harness.components).toEqual(["workspace", "config", "skills"]);
     expect(result.fileCount).toBeGreaterThan(0);
     expect(fs.existsSync(outputFile)).toBe(true);
   });
@@ -265,6 +268,16 @@ describe("export + import", () => {
 
     expect(result.manifest.packType).toBe("instance");
     expect(result.manifest.riskLevel).toBe("trusted-migration-only");
+    expect(result.manifest.harness.components).toEqual([
+      "workspace",
+      "config",
+      "skills",
+      "agents",
+      "credentials",
+      "sessions",
+      "memory",
+      "cron",
+    ]);
     expect(fs.existsSync(outputFile)).toBe(true);
   });
 
@@ -332,6 +345,7 @@ describe("export + import", () => {
 
     expect(importResult.targetDir).toBe(targetDir);
     expect(importResult.manifest.packType).toBe("template");
+    expect(importResult.manifest.harness.intent).toBe("agent-runtime-environment");
     expect(fs.existsSync(path.join(targetDir, "workspace", "AGENTS.md"))).toBe(true);
     expect(fs.existsSync(path.join(targetDir, "openclaw.json"))).toBe(true);
   });
@@ -409,6 +423,7 @@ describe("export + import", () => {
     const verifyResult = verify(targetDir, importResult.manifest);
     expect(verifyResult.valid).toBe(true);
     expect(verifyResult.errors).toHaveLength(0);
+    expect(verifyResult.checks.some(c => c.name === "manifest_harness" && c.passed)).toBe(true);
   });
 
   it("full round-trip with instance pack", async () => {
@@ -464,5 +479,37 @@ describe("verify", () => {
     const result = verify(instanceDir);
 
     expect(result.checks.some(c => c.name === "agents_present" && c.passed)).toBe(true);
+  });
+
+  it("warns when manifest harness metadata is missing", () => {
+    const instanceDir = createMockInstance(path.join(tmpDir, "verify-harness"));
+    const result = verify(instanceDir, {
+      schemaVersion: "0.3.0",
+      packType: "template",
+      packId: "legacy-pack",
+      createdAt: "2026-03-11T00:00:00.000Z",
+      source: {
+        product: "openclaw",
+        version: "unknown",
+        configPath: "openclaw.json",
+      },
+      includedPaths: ["openclaw.json", "workspace/AGENTS.md"],
+      workspaces: [],
+      sensitiveFlags: {
+        hasCredentials: false,
+        hasApiKeys: false,
+        hasOAuthTokens: false,
+        hasAuthProfiles: false,
+        hasWhatsAppCreds: false,
+        hasCopilotToken: false,
+        hasSessions: false,
+        hasMemoryDb: false,
+        hasEnvFile: false,
+      },
+      riskLevel: "safe-share",
+    } as any);
+
+    expect(result.checks.some(c => c.name === "manifest_harness" && !c.passed)).toBe(true);
+    expect(result.warnings.some(w => w.includes("reusable agent runtime environment"))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- add manifest-level harness metadata so .clawpack describes a reusable agent runtime environment
- populate harness components during export and backfill missing metadata when importing older packs
- extend verification and end-to-end tests for the new manifest intent

## Testing
- npm run build
- npx vitest run test/e2e.test.ts