### PR TITLE
Bootstrap local ccpm-codex and harness guardrails

### DIFF
--- a/.codex/pm/epics/repository-harness.md
+++ b/.codex/pm/epics/repository-harness.md
@@ -1,0 +1,32 @@
+---
+type: epic
+slug: repository-harness
+title: Repository Harness
+status: backlog
+prd: harness-bootstrap
+---
+
+## Outcome
+
+ClawPack gains a practical local harness for disciplined development and validation.
+
+## Scope
+
+- local PM workflow
+- hook and preflight guardrails
+- CLI smoke validation
+
+## Acceptance Criteria
+
+- harness commands are repository-local
+- hooks and preflight are documented and testable
+- smoke validation covers the documented CLI path
+
+## Child Issues
+
+- bootstrap ccpm-codex and local guardrails
+
+## Notes
+
+This epic intentionally excludes research-only workflows.
+

--- a/.codex/pm/issue-state/3-bootstrap-ccpm-codex.md
+++ b/.codex/pm/issue-state/3-bootstrap-ccpm-codex.md
@@ -1,0 +1,34 @@
+---
+type: issue_state
+issue: 3
+task: .codex/pm/tasks/repository-harness/bootstrap-ccpm-codex.md
+title: Bootstrap local ccpm-codex and harness guardrails
+status: done
+---
+
+## Summary
+
+Bootstrap the reusable harness core first so later ClawPack harness tasks can use the same issue-task-PR flow.
+
+## Validated Facts
+
+- ClawPack had no `.githooks/`, no `scripts/` harness layer, and no local issue-state support.
+- OpenPrecedent's reusable value is primarily workflow, guardrails, and validation structure rather than product-specific research features.
+- The first harness bootstrap issue is GitHub issue `#3`.
+
+## Open Questions
+
+- Which future ClawPack-specific harness tasks should become the next child tasks under `repository-harness`?
+
+## Next Steps
+
+- use the new local PM flow for the next ClawPack harness issue
+- split follow-up harness work into reusable guardrails vs ClawPack-specific validation tasks
+- decide which next issue should harden PR closure sync and merged-branch checks in everyday use
+
+## Artifacts
+
+- `scripts/codex-pm.mjs`
+- `.githooks/pre-push`
+- `scripts/run-agent-preflight.sh`
+- `scripts/run-cli-smoke.sh`

--- a/.codex/pm/prds/harness-bootstrap.md
+++ b/.codex/pm/prds/harness-bootstrap.md
@@ -1,0 +1,36 @@
+---
+type: prd
+slug: harness-bootstrap
+title: ClawPack Harness Bootstrap
+status: draft
+---
+
+## Summary
+
+Build the repository-local harness needed for issue-scoped agent development, local guardrails, and repeatable CLI validation.
+
+## Problem
+
+ClawPack currently has product code and tests, but it does not yet have a strong repository harness for disciplined issue-task-PR execution.
+
+## Goals
+
+- add local PM and issue-state support
+- add pre-push and preflight guardrails
+- add a standard CLI smoke validation path
+
+## Non-Goals
+
+- add OpenPrecedent research workflows
+- add OpenClaw live-runtime validation harnesses
+
+## Success Criteria
+
+- developers can run a local issue-task-PR workflow inside the repository
+- common workflow failures are blocked before push
+- the public CLI path is validated through a standard smoke command
+
+## Dependencies
+
+- Node.js 20+
+

--- a/.codex/pm/tasks/repository-harness/bootstrap-ccpm-codex.md
+++ b/.codex/pm/tasks/repository-harness/bootstrap-ccpm-codex.md
@@ -1,0 +1,43 @@
+---
+type: task
+epic: repository-harness
+slug: bootstrap-ccpm-codex
+title: Bootstrap local ccpm-codex and harness guardrails
+status: done
+task_type: implementation
+labels: feature,tooling,test
+issue: 3
+state_path: .codex/pm/issue-state/3-bootstrap-ccpm-codex.md
+---
+
+## Context
+
+ClawPack needs a repository-local PM workflow, issue state, hook guardrails, and smoke validation before broader harness work can proceed safely.
+
+## Deliverable
+
+Add local PM tooling, hook/preflight scripts, and a standard CLI smoke validation path without making ClawPack depend on OpenPrecedent.
+
+## Scope
+
+- add repository-local PM/task/state tooling
+- add review checkpoint, pre-push, and preflight scripts
+- add CLI smoke validation
+- update docs and agent guidance
+
+## Acceptance Criteria
+
+- local PM commands scaffold and render task documents
+- pre-push blocks missing review proof and stale merged branches
+- preflight runs build, tests, and optional smoke checks
+- import persists manifest so CLI verify can validate imported packs
+
+## Validation
+
+- `npm run build`
+- `npm test`
+- `./scripts/run-cli-smoke.sh`
+
+## Implementation Notes
+
+Use Node-based local scripts so the harness remains self-contained for a TypeScript CLI repository.

--- a/.codex/skills/ccpm-codex/SKILL.md
+++ b/.codex/skills/ccpm-codex/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: ccpm-codex
+description: Use when work in this repository should follow an issue-task-PR workflow with local task twins, issue state, and repository-local PR body generation.
+---
+
+# CCPM For Codex
+
+Use this skill for project-management work in this repository when the task involves PRDs, epics, task decomposition, issue-scoped execution, or PR body generation.
+
+## Workflow
+
+1. Initialize the local PM workspace if `.codex/pm/` is missing:
+   - `node scripts/codex-pm.mjs init`
+2. Create or update planning documents:
+   - PRD: `node scripts/codex-pm.mjs prd-new <slug> --title "<title>"`
+   - Epic: `node scripts/codex-pm.mjs epic-new <slug> --title "<title>" --prd <prd-slug>`
+   - Task: `node scripts/codex-pm.mjs task-new <epic> <slug> --title "<title>" --issue <n> --labels feature,test`
+3. Treat each task file as the local twin of one GitHub issue.
+4. Keep task status in sync with branch and PR state:
+   - start work: `node scripts/codex-pm.mjs set-status <task-path> in_progress`
+   - blocked: `node scripts/codex-pm.mjs blocked <task-path> --reason "..."`
+   - merged: `node scripts/codex-pm.mjs set-status <task-path> done`
+5. Initialize issue-scoped state for work that may span sessions:
+   - `node scripts/codex-pm.mjs issue-state-init <task-path>`
+6. Generate GitHub text from the task file:
+   - issue body: `node scripts/codex-pm.mjs issue-body <task-path>`
+   - PR body: `node scripts/codex-pm.mjs pr-body <task-path> --issue <n> --tests "npm test"`
+   - PR creation: `node scripts/codex-pm.mjs pr-create <task-path> --tests "npm test"`
+
+## Repository Rules
+
+- One issue per branch.
+- One issue per PR.
+- Always branch from the latest `upstream/main`.
+- Use `Closes #<issue>` in the PR body for non-umbrella tasks.
+- Do not append commits to a branch whose PR has already been merged.
+

--- a/.codex/skills/harness-gap-closure/SKILL.md
+++ b/.codex/skills/harness-gap-closure/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: harness-gap-closure
+description: Use when a repeated workflow mistake or user reminder shows the local harness should have prevented the problem. Add the smallest guardrail and regression coverage.
+---
+
+# Harness Gap Closure
+
+Use this skill when a failure should have been prevented by the repository's local harness rather than left to user correction or memory.
+
+## Goal
+
+Turn repeated workflow failures into concrete harness hardening work:
+
+1. identify the harness gap
+2. link it to one explicit task or issue
+3. implement the smallest reliable guardrail
+4. add regression protection
+5. update repository guidance where future sessions will see it
+
+## Typical Fixes
+
+- pre-push hook checks
+- preflight checks
+- repository-local command wrappers
+- workflow skill instructions
+- fail-fast validation scripts
+

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+review_file="${CLAWPACK_REVIEW_FILE:-$repo_root/.codex-review}"
+review_proof_file="${CLAWPACK_REVIEW_PROOF_FILE:-$repo_root/.codex-review-proof}"
+base_ref="${CLAWPACK_BASE_REF:-upstream/main}"
+current_branch="$(git branch --show-current)"
+origin_url="$(git remote get-url origin 2>/dev/null || true)"
+upstream_url="$(git remote get-url upstream 2>/dev/null || true)"
+
+extract_repo() {
+  local remote_url="$1"
+  if [[ "$remote_url" =~ github\.com[:/]([^/]+)/([^/.]+?)(\.git)?$ ]]; then
+    echo "${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+    return 0
+  fi
+  return 1
+}
+
+extract_owner() {
+  local remote_url="$1"
+  if [[ "$remote_url" =~ github\.com[:/]([^/]+)/[^/]+(\.git)?$ ]]; then
+    echo "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  return 1
+}
+
+read_proof_value() {
+  local key="$1"
+  sed -n "s/^${key}=//p" "$review_proof_file" | head -n 1
+}
+
+check_branch_freshness() {
+  if [[ "${BYPASS_BRANCH_FRESHNESS_CHECK:-}" == "1" ]]; then
+    echo "Bypassing branch freshness check because BYPASS_BRANCH_FRESHNESS_CHECK=1"
+    return 0
+  fi
+
+  if ! git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+    echo "Skipping branch freshness check: base ref $base_ref is unavailable"
+    return 0
+  fi
+
+  if ! git merge-base --is-ancestor "$base_ref" HEAD; then
+    cat <<EOF
+Push blocked: current branch does not contain the latest $base_ref.
+
+Rebase or merge $base_ref into the current branch before pushing.
+EOF
+    exit 1
+  fi
+}
+
+run_local_pr_closure_check() {
+  local changed_files pr_body body_input=() base_repo owner
+
+  if [[ -z "$current_branch" ]]; then
+    return 0
+  fi
+
+  if ! git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+    echo "Skipping local closure sync check: base ref $base_ref is unavailable"
+    return 0
+  fi
+
+  changed_files="$(git diff --name-only "$base_ref"...HEAD)"
+  if [[ -z "$changed_files" ]]; then
+    return 0
+  fi
+
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "Skipping local closure sync check: gh is unavailable"
+    return 0
+  fi
+
+  pr_body="$(gh pr view --json body --jq .body 2>/dev/null || true)"
+  if [[ -z "$pr_body" ]]; then
+    echo "Skipping local closure sync check: PR body is unavailable"
+    return 0
+  fi
+
+  while IFS= read -r changed_path; do
+    [[ -n "$changed_path" ]] || continue
+    body_input+=("--changed-file" "$changed_path")
+  done <<< "$changed_files"
+
+  node "$repo_root/scripts/codex-pm.mjs" verify-pr-closure-sync --pr-body "$pr_body" "${body_input[@]}"
+
+  if owner="$(extract_owner "$origin_url")" && base_repo="$(extract_repo "$upstream_url")"; then
+    merged_pr_json="$(
+      gh pr list \
+        --repo "$base_repo" \
+        --head "$owner:$current_branch" \
+        --state merged \
+        --json number,url \
+        2>/dev/null || true
+    )"
+    if [[ "$merged_pr_json" != "[]" ]] && [[ -n "$merged_pr_json" ]]; then
+      cat <<EOF
+Push blocked: the current branch already has a merged PR in $base_repo.
+
+Branch: $current_branch
+
+Create a new branch from $base_ref for follow-up work instead of pushing more commits to a merged PR branch.
+EOF
+      exit 1
+    fi
+  fi
+}
+
+check_branch_freshness
+
+if [[ ! -f "$review_file" ]]; then
+  cat <<'EOF'
+Push blocked: missing .codex-review
+
+Before pushing, run:
+  ./scripts/run-codex-review-checkpoint.sh
+
+Then update .codex-review with:
+  - scope reviewed
+  - findings or "no findings"
+  - remaining risks
+EOF
+  exit 1
+fi
+
+if ! grep -Eq '^scope reviewed:' "$review_file" \
+  || ! grep -Eq '^findings:' "$review_file" \
+  || ! grep -Eq '^remaining risks:' "$review_file"; then
+  cat <<'EOF'
+Push blocked: .codex-review exists but is incomplete.
+
+Include at least:
+  - scope reviewed
+  - findings
+  - remaining risks
+EOF
+  exit 1
+fi
+
+if grep -Fq 'native /review has not been run yet' "$review_file"; then
+  cat <<'EOF'
+Push blocked: .codex-review still contains the checkpoint placeholder.
+
+Run the native Codex /review flow and replace the placeholder text with the real review outcome before pushing.
+EOF
+  exit 1
+fi
+
+if [[ ! -f "$review_proof_file" ]]; then
+  cat <<'EOF'
+Push blocked: missing .codex-review-proof
+
+Before pushing, run:
+  ./scripts/run-codex-review-checkpoint.sh
+EOF
+  exit 1
+fi
+
+proof_head_sha="$(read_proof_value head_sha)"
+proof_branch="$(read_proof_value branch)"
+current_head_sha="$(git rev-parse HEAD)"
+
+if [[ -z "$proof_head_sha" ]]; then
+  echo "Push blocked: .codex-review-proof is missing head_sha."
+  exit 1
+fi
+
+if [[ "$proof_head_sha" != "$current_head_sha" ]]; then
+  cat <<EOF
+Push blocked: .codex-review-proof does not match the current HEAD.
+
+Proof HEAD:   $proof_head_sha
+Current HEAD: $current_head_sha
+
+Rerun ./scripts/run-codex-review-checkpoint.sh and update .codex-review after the native Codex /review step.
+EOF
+  exit 1
+fi
+
+if [[ -n "$current_branch" ]] && [[ -n "$proof_branch" ]] && [[ "$proof_branch" != "$current_branch" ]]; then
+  cat <<EOF
+Push blocked: .codex-review-proof was generated for a different branch.
+
+Proof branch:   $proof_branch
+Current branch: $current_branch
+EOF
+  exit 1
+fi
+
+if [[ "$review_file" -ot "$review_proof_file" ]]; then
+  cat <<'EOF'
+Push blocked: .codex-review has not been updated since the latest review checkpoint.
+EOF
+  exit 1
+fi
+
+run_local_pr_closure_check
+
+echo "Codex review note detected."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,10 @@ ClawPack is an application-layer packaging and distribution CLI for OpenClaw age
 ```bash
 npm run build          # compile TypeScript (tsc)
 npm test               # run all tests (vitest run)
+npm run preflight      # build + tests + local harness checks
+npm run smoke          # CLI smoke validation
+npm run review:checkpoint  # create/update .codex-review + proof
+npm run pm -- init     # initialize local PM workspace
 npm run test:watch     # run tests in watch mode
 npx vitest run test/e2e.test.ts              # run a single test file
 npx vitest run -t "exports a template pack"  # run a single test by name
@@ -37,6 +41,14 @@ src/utils/
 
 Tests are in `test/e2e.test.ts` — a single file that tests the core modules directly (scanner, packer, verifier) using temp directories.
 
+Harness and workflow support lives in:
+
+- `.codex/skills/ccpm-codex/` — local issue-task-PR workflow guidance
+- `.codex/skills/harness-gap-closure/` — convert repeated workflow failures into guardrails
+- `.codex/pm/` — local PRD/epic/task/state documents
+- `.githooks/pre-push` — local review/proof/closure guardrail
+- `scripts/` — PM, review checkpoint, preflight, and CLI smoke commands
+
 ## Key Concepts
 
 - **PackType**: `"template"` (excludes secrets, safe to share) vs `"instance"` (full migration, includes everything)
@@ -52,3 +64,6 @@ Tests are in `test/e2e.test.ts` — a single file that tests the core modules di
 - File paths use `node:path` and `node:fs` — no third-party fs utilities
 - Archive handling uses the `tar` npm package
 - Import paths in source use `.js` extensions (ESM convention)
+- Use `node scripts/codex-pm.mjs` for repository-local task, issue-state, and PR-body workflows instead of ad hoc notes
+- Before push, prefer `./scripts/run-codex-review-checkpoint.sh` and `./scripts/run-agent-preflight.sh`
+- Any repeated workflow mistake that should have been blocked locally should be treated as a harness gap and fixed through the local guardrail layer

--- a/docs/engineering/tooling-setup.md
+++ b/docs/engineering/tooling-setup.md
@@ -1,0 +1,67 @@
+# Tooling Setup
+
+## Repository-Local Setup
+
+The repository now includes:
+
+- a local Git pre-push hook that requires a Codex review note and review proof
+- `scripts/run-codex-review-checkpoint.sh` as the local checkpoint for invoking native Codex `/review`
+- `scripts/run-agent-preflight.sh` for the standard local pre-push confidence checks
+- `scripts/run-cli-smoke.sh` for the standard CLI smoke validation path
+- `node scripts/codex-pm.mjs issue-state-init <task-path>` for preserving issue-scoped state across longer work
+
+To enable the local hook:
+
+```bash
+./scripts/install-hooks.sh
+```
+
+After that, each push requires both a `.codex-review` file and a current `.codex-review-proof` file in the repository root unless you explicitly bypass the hook. The hook also expects your branch to contain the latest `upstream/main` by default.
+
+## Codex Review Hook
+
+Before pushing, run:
+
+```bash
+./scripts/run-codex-review-checkpoint.sh
+```
+
+Then update `.codex-review` with a short review note:
+
+```text
+scope reviewed: hook and preflight changes
+findings: no findings
+remaining risks: smoke validation was not run locally
+```
+
+## Merge Validation
+
+For the standard local readiness pass before push, run:
+
+```bash
+./scripts/run-agent-preflight.sh
+```
+
+This checks the local review note, review proof, issue-state, build, tests, and local PR closure sync when `gh` can resolve the current PR body.
+
+Set `CLAWPACK_PREFLIGHT_RUN_SMOKE=1` if you also want the CLI smoke path included in the same pass.
+
+## Issue-Scoped Development State
+
+For longer-running issues, initialize a local state document from the matching task twin:
+
+```bash
+node scripts/codex-pm.mjs issue-state-init .codex/pm/tasks/<epic>/<task>.md
+```
+
+Use it to keep validated facts, open questions, next steps, and key artifacts in one stable place as the work evolves across sessions.
+
+## CLI Smoke Validation
+
+For a standard documented-user-path validation, run:
+
+```bash
+./scripts/run-cli-smoke.sh
+```
+
+This validates the public `inspect -> export -> import -> verify` path against a temporary OpenClaw-style fixture and requires `verify` to load the persisted imported manifest.

--- a/package.json
+++ b/package.json
@@ -13,9 +13,13 @@
     "README.md"
   ],
   "scripts": {
+    "pm": "node scripts/codex-pm.mjs",
     "build": "tsc",
     "dev": "tsc --watch",
     "start": "node dist/cli.js",
+    "review:checkpoint": "./scripts/run-codex-review-checkpoint.sh",
+    "preflight": "./scripts/run-agent-preflight.sh",
+    "smoke": "./scripts/run-cli-smoke.sh",
     "test": "vitest run",
     "test:watch": "vitest",
     "prepublishOnly": "npm run build && npm test"

--- a/scripts/codex-pm.mjs
+++ b/scripts/codex-pm.mjs
@@ -1,0 +1,708 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { spawnSync } from "node:child_process";
+
+const PM_ROOT = path.join(".codex", "pm");
+const ISSUE_STATE_ROOT = path.join(PM_ROOT, "issue-state");
+const VALID_STATUSES = ["backlog", "in_progress", "blocked", "done"];
+const VALID_TASK_TYPES = ["implementation", "docs", "ops", "umbrella"];
+const CLOSING_ISSUE_PATTERN = /\b(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s+#(\d+)\b/gi;
+const GITHUB_REMOTE_PATTERN = /github\.com[:/]([^/]+)\/([^/.]+?)(?:\.git)?$/;
+
+export function main(argv = process.argv.slice(2), io = console) {
+  const [action, ...args] = argv;
+  if (!action) {
+    io.error("Usage: node scripts/codex-pm.mjs <action> [args]");
+    return 1;
+  }
+
+  try {
+    switch (action) {
+      case "init":
+        initPm();
+        return 0;
+      case "prd-new":
+        return prdNew(args, io);
+      case "epic-new":
+        return epicNew(args, io);
+      case "task-new":
+        return taskNew(args, io);
+      case "tasks":
+        return listTasks(args, io);
+      case "next":
+        return nextTask(args, io);
+      case "set-status":
+        return setStatus(args, io);
+      case "blocked":
+        return blocked(args, io);
+      case "issue-state-init":
+        return issueStateInit(args, io);
+      case "issue-state-show":
+        return issueStateShow(args, io);
+      case "issue-state-check":
+        return issueStateCheck(args, io);
+      case "standup":
+        return standup(args, io);
+      case "issue-body":
+        return issueBody(args, io);
+      case "pr-body":
+        return prBody(args, io);
+      case "pr-create":
+        return prCreate(args, io);
+      case "verify-pr-closure-sync":
+        return verifyPrClosureSync(args, io);
+      default:
+        io.error(`Unknown action: ${action}`);
+        return 1;
+    }
+  } catch (error) {
+    io.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}
+
+function initPm() {
+  for (const name of ["prds", "epics", "tasks", "issue-state", "updates", "context"]) {
+    fs.mkdirSync(path.join(PM_ROOT, name), { recursive: true });
+  }
+}
+
+function prdNew(args, io) {
+  const { positional, options } = parseArgs(args);
+  const [slug] = positional;
+  const title = options.title;
+  requireValue(slug, "slug is required");
+  requireValue(title, "--title is required");
+  initPm();
+  const prdPath = path.join(PM_ROOT, "prds", `${slug}.md`);
+  writeDocument(prdPath, {
+    type: "prd",
+    slug,
+    title,
+    status: "draft",
+  }, {
+    Summary: "",
+    Problem: "",
+    Goals: "- ",
+    "Non-Goals": "- ",
+    "Success Criteria": "- ",
+    Dependencies: "- ",
+  });
+  io.log(prdPath);
+  return 0;
+}
+
+function epicNew(args, io) {
+  const { positional, options } = parseArgs(args);
+  const [slug] = positional;
+  const title = options.title;
+  requireValue(slug, "slug is required");
+  requireValue(title, "--title is required");
+  initPm();
+  const metadata = {
+    type: "epic",
+    slug,
+    title,
+    status: "backlog",
+  };
+  if (options.prd) metadata.prd = options.prd;
+  const epicPath = path.join(PM_ROOT, "epics", `${slug}.md`);
+  writeDocument(epicPath, metadata, {
+    Outcome: "",
+    Scope: "- ",
+    "Acceptance Criteria": "- ",
+    "Child Issues": "- ",
+    Notes: "",
+  });
+  io.log(epicPath);
+  return 0;
+}
+
+function taskNew(args, io) {
+  const { positional, options } = parseArgs(args);
+  const [epic, slug] = positional;
+  requireValue(epic, "epic is required");
+  requireValue(slug, "slug is required");
+  requireValue(options.title, "--title is required");
+  validateEnum(options.status ?? "backlog", VALID_STATUSES, "--status");
+  validateEnum(options["task-type"] ?? "implementation", VALID_TASK_TYPES, "--task-type");
+  initPm();
+  const taskPath = path.join(PM_ROOT, "tasks", epic, `${slug}.md`);
+  const metadata = {
+    type: "task",
+    epic,
+    slug,
+    title: options.title,
+    status: options.status ?? "backlog",
+    task_type: options["task-type"] ?? "implementation",
+    labels: options.labels ?? "",
+    depends_on: options["depends-on"] ?? "",
+  };
+  if (options.issue) metadata.issue = options.issue;
+  writeDocument(taskPath, metadata, {
+    Context: "",
+    Deliverable: "",
+    Scope: "- ",
+    "Acceptance Criteria": "- ",
+    Validation: "- ",
+    "Implementation Notes": "",
+  });
+  io.log(taskPath);
+  return 0;
+}
+
+function listTasks(args, io) {
+  const { options } = parseArgs(args);
+  const docs = loadTasks({ status: options.status, epic: options.epic });
+  if (options.json) {
+    io.log(JSON.stringify(docs.map(docToDict), null, 2));
+    return 0;
+  }
+  for (const doc of docs) {
+    const issue = doc.metadata.issue ? ` issue=${doc.metadata.issue}` : "";
+    io.log(`${doc.path} status=${doc.metadata.status ?? "backlog"}${issue}`);
+  }
+  return 0;
+}
+
+function nextTask(args, io) {
+  const { options } = parseArgs(args);
+  const docs = loadTasks({ epic: options.epic }).filter((doc) => (doc.metadata.status ?? "backlog") === "backlog");
+  if (docs.length === 0) {
+    io.log(options.json ? "null" : "No backlog task found.");
+    return 0;
+  }
+  const task = docs[0];
+  io.log(options.json ? JSON.stringify(docToDict(task), null, 2) : task.path);
+  return 0;
+}
+
+function setStatus(args, io) {
+  const { positional, options } = parseArgs(args);
+  const [filePath, status] = positional;
+  requireValue(filePath, "path is required");
+  requireValue(status, "status is required");
+  validateEnum(status, VALID_STATUSES, "status");
+  const document = readDocument(filePath);
+  document.metadata.status = status;
+  if (options.reason) {
+    document.metadata.status_reason = options.reason;
+  } else {
+    delete document.metadata.status_reason;
+  }
+  persistDocument(document);
+  io.log(document.path);
+  return 0;
+}
+
+function blocked(args, io) {
+  const { positional, options } = parseArgs(args);
+  const [filePath] = positional;
+  requireValue(filePath, "path is required");
+  requireValue(options.reason, "--reason is required");
+  const document = readDocument(filePath);
+  document.metadata.status = "blocked";
+  document.metadata.status_reason = options.reason;
+  persistDocument(document);
+  io.log(document.path);
+  return 0;
+}
+
+function issueStateInit(args, io) {
+  const { positional } = parseArgs(args);
+  const [filePath] = positional;
+  requireValue(filePath, "path is required");
+  const taskDocument = readDocument(filePath);
+  const stateDocument = initIssueState(taskDocument);
+  io.log(stateDocument.path);
+  return 0;
+}
+
+function issueStateShow(args, io) {
+  const { positional } = parseArgs(args);
+  const [filePath] = positional;
+  requireValue(filePath, "path is required");
+  const taskDocument = readDocument(filePath);
+  const stateDocument = loadIssueState(taskDocument);
+  if (!stateDocument) {
+    io.error("No issue state document found for task.");
+    return 1;
+  }
+  io.log(stateDocument.path);
+  io.log("");
+  io.log(fs.readFileSync(stateDocument.path, "utf8").trimEnd());
+  return 0;
+}
+
+function issueStateCheck(args, io) {
+  const { options } = parseArgs(args);
+  const branch = options.branch ?? currentBranch();
+  const result = checkIssueState(branch);
+  if (result === null) {
+    io.log("Issue state check skipped: current branch is not issue-scoped.");
+    return 0;
+  }
+  if (result.ok) {
+    io.log(result.message);
+    return 0;
+  }
+  io.error(result.message);
+  return 1;
+}
+
+function standup(args, io) {
+  const { options } = parseArgs(args);
+  const summary = {
+    backlog: [],
+    in_progress: [],
+    blocked: [],
+    done: [],
+  };
+  for (const document of loadTasks({})) {
+    const status = summary[document.metadata.status ?? "backlog"] ? (document.metadata.status ?? "backlog") : "backlog";
+    summary[status].push(docToDict(document));
+  }
+  if (options.json) {
+    io.log(JSON.stringify(summary, null, 2));
+    return 0;
+  }
+  for (const status of VALID_STATUSES) {
+    io.log(`${status}: ${summary[status].length}`);
+    for (const item of summary[status]) {
+      io.log(`  - ${item.title} (${item.path})`);
+    }
+  }
+  return 0;
+}
+
+function issueBody(args, io) {
+  const { positional } = parseArgs(args);
+  const [filePath] = positional;
+  requireValue(filePath, "path is required");
+  const document = readDocument(filePath);
+  io.log(renderIssueBody(document));
+  return 0;
+}
+
+function prBody(args, io) {
+  const { positional, options } = parseArgs(args);
+  const [filePath] = positional;
+  requireValue(filePath, "path is required");
+  const document = readDocument(filePath);
+  const tests = asArray(options.tests);
+  const issue = options.issue ? Number(options.issue) : undefined;
+  io.log(renderPrBody(document, { issue, tests }));
+  return 0;
+}
+
+function prCreate(args, io) {
+  const { positional, options } = parseArgs(args);
+  const [filePath] = positional;
+  requireValue(filePath, "path is required");
+  const document = readDocument(filePath);
+  const tests = asArray(options.tests);
+  const issue = options.issue ? Number(options.issue) : undefined;
+  const prUrl = createPr(document, {
+    issue,
+    tests,
+    title: options.title,
+    baseRepo: options["base-repo"] ?? inferBaseRepo() ?? "Mrxuexi/clawpack",
+    baseBranch: options["base-branch"] ?? "main",
+    headOwner: options["head-owner"],
+    headBranch: options["head-branch"],
+  });
+  io.log(prUrl);
+  return 0;
+}
+
+function verifyPrClosureSync(args, io) {
+  const { options } = parseArgs(args);
+  const prBody = resolvePrBody(options);
+  const changedFiles = resolveChangedFiles(options);
+  const errors = verifyClosureSync(prBody, changedFiles);
+  if (errors.length > 0) {
+    for (const error of errors) {
+      io.error(error);
+    }
+    return 1;
+  }
+  io.log("PR task closure sync passed.");
+  return 0;
+}
+
+export function parseArgs(args) {
+  const positional = [];
+  const options = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (!token.startsWith("--")) {
+      positional.push(token);
+      continue;
+    }
+    const key = token.slice(2);
+    const next = args[index + 1];
+    if (next === undefined || next.startsWith("--")) {
+      options[key] = true;
+      continue;
+    }
+    if (Object.prototype.hasOwnProperty.call(options, key)) {
+      const current = options[key];
+      options[key] = Array.isArray(current) ? [...current, next] : [current, next];
+    } else {
+      options[key] = next;
+    }
+    index += 1;
+  }
+  return { positional, options };
+}
+
+function writeDocument(filePath, metadata, sections) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  persistDocument({ path: filePath, metadata: { ...metadata }, sections: { ...sections } });
+}
+
+export function persistDocument(document) {
+  const lines = ["---"];
+  for (const [key, value] of Object.entries(document.metadata)) {
+    if (value) lines.push(`${key}: ${value}`);
+  }
+  lines.push("---", "");
+  for (const [heading, body] of Object.entries(document.sections)) {
+    lines.push(`## ${heading}`, "");
+    if (body) lines.push(...String(body).replace(/\s+$/u, "").split("\n"));
+    lines.push("");
+  }
+  fs.writeFileSync(document.path, `${lines.join("\n").replace(/\n+$/u, "\n")}`, "utf8");
+}
+
+export function readDocument(filePath) {
+  const text = fs.readFileSync(filePath, "utf8");
+  if (!text.startsWith("---\n")) {
+    throw new Error(`document missing frontmatter: ${filePath}`);
+  }
+  const parts = text.split("---\n");
+  const frontmatter = parts[1] ?? "";
+  const body = parts.slice(2).join("---\n");
+  const metadata = {};
+  for (const line of frontmatter.trim().split("\n")) {
+    if (!line.trim()) continue;
+    const separator = line.indexOf(":");
+    metadata[line.slice(0, separator).trim()] = line.slice(separator + 1).trim();
+  }
+  const sections = {};
+  let currentHeading = null;
+  let currentLines = [];
+  for (const line of body.split("\n")) {
+    if (line.startsWith("## ")) {
+      if (currentHeading) sections[currentHeading] = currentLines.join("\n").trim();
+      currentHeading = line.slice(3).trim();
+      currentLines = [];
+      continue;
+    }
+    if (currentHeading) currentLines.push(line);
+  }
+  if (currentHeading) sections[currentHeading] = currentLines.join("\n").trim();
+  return { path: String(filePath), metadata, sections };
+}
+
+export function loadTasks({ status, epic }) {
+  const base = path.join(PM_ROOT, "tasks");
+  if (!fs.existsSync(base)) return [];
+  const results = [];
+  for (const epicDir of fs.readdirSync(base, { withFileTypes: true })) {
+    if (!epicDir.isDirectory()) continue;
+    if (epic && epicDir.name !== epic) continue;
+    const fullEpic = path.join(base, epicDir.name);
+    for (const entry of fs.readdirSync(fullEpic, { withFileTypes: true })) {
+      if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
+      const document = readDocument(path.join(fullEpic, entry.name));
+      if (status && document.metadata.status !== status) continue;
+      results.push(document);
+    }
+  }
+  return sortTasks(results);
+}
+
+function sortTasks(documents) {
+  return [...documents].sort((left, right) => {
+    const leftIssue = Number.parseInt(left.metadata.issue ?? "999999", 10);
+    const rightIssue = Number.parseInt(right.metadata.issue ?? "999999", 10);
+    return (
+      compare(left.metadata.epic ?? "", right.metadata.epic ?? "") ||
+      compare(statusRank(left.metadata.status ?? "backlog"), statusRank(right.metadata.status ?? "backlog")) ||
+      compare(Number.isNaN(leftIssue) ? 999999 : leftIssue, Number.isNaN(rightIssue) ? 999999 : rightIssue) ||
+      compare(left.metadata.title ?? "", right.metadata.title ?? "") ||
+      compare(left.path, right.path)
+    );
+  });
+}
+
+function statusRank(status) {
+  const index = VALID_STATUSES.indexOf(status);
+  return index === -1 ? VALID_STATUSES.length : index;
+}
+
+export function docToDict(document) {
+  return {
+    path: document.path,
+    title: document.metadata.title ?? "",
+    status: document.metadata.status ?? "",
+    epic: document.metadata.epic ?? "",
+    issue: document.metadata.issue ?? undefined,
+    state_path: document.metadata.state_path ?? undefined,
+    task_type: document.metadata.task_type ?? "implementation",
+    labels: (document.metadata.labels ?? "").split(",").map((item) => item.trim()).filter(Boolean),
+  };
+}
+
+function issueStatePath(document) {
+  const issue = parseIssueNumber(document.metadata.issue ?? "");
+  if (issue === null) throw new Error(`task has no numeric issue reference: ${document.path}`);
+  const slug = document.metadata.slug ?? path.basename(document.path, ".md");
+  return path.join(ISSUE_STATE_ROOT, `${issue}-${slug}.md`);
+}
+
+export function initIssueState(taskDocument) {
+  const filePath = issueStatePath(taskDocument);
+  if (!fs.existsSync(filePath)) {
+    writeDocument(filePath, {
+      type: "issue_state",
+      issue: taskDocument.metadata.issue ?? "",
+      task: taskDocument.path,
+      title: taskDocument.metadata.title ?? "",
+      status: taskDocument.metadata.status ?? "",
+    }, {
+      Summary: "Record the current working state for this issue so later sessions do not have to rediscover it.",
+      "Validated Facts": "- ",
+      "Open Questions": "- ",
+      "Next Steps": "- ",
+      Artifacts: "- ",
+    });
+  }
+  taskDocument.metadata.state_path = filePath;
+  persistDocument(taskDocument);
+  return readDocument(filePath);
+}
+
+function loadIssueState(taskDocument) {
+  const candidates = [];
+  if (taskDocument.metadata.state_path) candidates.push(taskDocument.metadata.state_path);
+  try {
+    candidates.push(issueStatePath(taskDocument));
+  } catch {
+    // ignore
+  }
+  for (const candidate of candidates) {
+    if (candidate && fs.existsSync(candidate)) return readDocument(candidate);
+  }
+  return null;
+}
+
+function checkIssueState(branch) {
+  const issue = parseIssueFromBranch(branch);
+  if (issue === null) return null;
+  const task = findTaskByIssue(issue);
+  if (!task) {
+    return { ok: false, message: `Issue state check failed: no task twin found for issue #${issue}.` };
+  }
+  if ((task.metadata.status ?? "backlog") !== "in_progress") {
+    return { ok: true, message: `Issue state check skipped: task for issue #${issue} is not in progress.` };
+  }
+  const stateDocument = loadIssueState(task);
+  if (!stateDocument) {
+    return {
+      ok: false,
+      message: `Issue state check failed: in-progress issue has no state document. Run \`node scripts/codex-pm.mjs issue-state-init ${task.path}\`.`,
+    };
+  }
+  return { ok: true, message: `Issue state check passed: ${stateDocument.path}` };
+}
+
+function findTaskByIssue(issue) {
+  return loadTasks({}).find((document) => parseIssueNumber(document.metadata.issue ?? "") === issue) ?? null;
+}
+
+export function renderIssueBody(document) {
+  const lines = [];
+  for (const heading of ["Context", "Deliverable", "Scope", "Acceptance Criteria"]) {
+    const body = document.sections[heading];
+    if (!body) continue;
+    lines.push(`## ${heading}`, body, "");
+  }
+  if (document.metadata.task_type) {
+    lines.push("## Task Type", document.metadata.task_type, "");
+  }
+  if (document.metadata.labels) {
+    lines.push("## Labels", document.metadata.labels, "");
+  }
+  return lines.join("\n").trimEnd();
+}
+
+export function renderPrBody(document, { issue, tests }) {
+  const lines = [];
+  const taskType = document.metadata.task_type ?? "implementation";
+  const closingIssue = issue ?? parseIssueNumber(document.metadata.issue ?? "");
+  if (closingIssue !== null && closingIssue !== undefined && taskType !== "umbrella") {
+    lines.push(`Closes #${closingIssue}`, "");
+  }
+  if (document.sections.Deliverable) {
+    lines.push(document.sections.Deliverable, "");
+  }
+  if (document.sections["Implementation Notes"]) {
+    lines.push("Implementation notes:", document.sections["Implementation Notes"], "");
+  }
+  const renderedTests = [];
+  if (document.sections.Validation) {
+    for (const line of document.sections.Validation.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed === "-") continue;
+      renderedTests.push(line);
+    }
+  }
+  for (const test of tests ?? []) renderedTests.push(`- \`${test}\``);
+  if (renderedTests.length > 0) {
+    lines.push("Validation:", ...renderedTests);
+  }
+  return lines.join("\n").trimEnd();
+}
+
+function createPr(document, { issue, tests, title, baseRepo, baseBranch, headOwner, headBranch }) {
+  const branch = headBranch ?? currentBranch();
+  if (!branch) throw new Error("PR creation failed: current branch is unavailable.");
+  const originUrl = gitOutput(["remote", "get-url", "origin"]);
+  const derivedOwner = headOwner ?? parseGithubRemote(originUrl)?.owner;
+  if (!derivedOwner) {
+    throw new Error("PR creation failed: could not derive the fork owner from origin. Pass --head-owner explicitly.");
+  }
+  const upstream = parseGithubRemote(gitOutput(["remote", "get-url", "upstream"]));
+  if (upstream) {
+    const inferred = `${upstream.owner}/${upstream.repo}`;
+    if (inferred !== baseRepo) {
+      throw new Error(`PR creation failed: upstream remote points to ${inferred}, not ${baseRepo}.`);
+    }
+  }
+  const body = renderPrBody(document, { issue, tests });
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawpack-pr-body-"));
+  const bodyPath = path.join(tempDir, "pr-body.md");
+  fs.writeFileSync(bodyPath, body, "utf8");
+  try {
+    const result = spawnSync("gh", [
+      "pr", "create",
+      "--repo", baseRepo,
+      "--base", baseBranch,
+      "--head", `${derivedOwner}:${branch}`,
+      "--title", title ?? document.metadata.title ?? path.basename(document.path, ".md"),
+      "--body-file", bodyPath,
+    ], { encoding: "utf8" });
+    if (result.status !== 0) {
+      throw new Error((result.stderr || result.stdout || "gh pr create failed").trim());
+    }
+    return result.stdout.trim();
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+export function verifyClosureSync(prBody, changedFiles) {
+  const closingIssues = [...prBody.matchAll(CLOSING_ISSUE_PATTERN)].map((match) => Number.parseInt(match[1], 10));
+  if (closingIssues.length === 0) return [];
+  const taskDocuments = changedFiles
+    .filter((filePath) => filePath.startsWith(".codex/pm/tasks/") && filePath.endsWith(".md") && fs.existsSync(filePath))
+    .map((filePath) => readDocument(filePath));
+  const errors = [];
+  for (const issue of [...new Set(closingIssues)]) {
+    const matching = taskDocuments.filter((document) => parseIssueNumber(document.metadata.issue ?? "") === issue);
+    if (matching.length === 0) {
+      errors.push(`PR closes #${issue} but does not update the matching local task file under .codex/pm/tasks/.`);
+      continue;
+    }
+    const umbrella = matching.filter((document) => (document.metadata.task_type ?? "implementation") === "umbrella");
+    if (umbrella.length > 0) {
+      errors.push(`PR closes #${issue} but matching task file is task_type=umbrella and must remain open: ${umbrella.map((doc) => doc.path).join(", ")}`);
+      continue;
+    }
+    if (!matching.some((document) => document.metadata.status === "done")) {
+      errors.push(`PR closes #${issue} but matching task file is not marked done: ${matching.map((doc) => doc.path).join(", ")}`);
+    }
+  }
+  return errors;
+}
+
+function resolvePrBody(options) {
+  if (options["pr-body"]) return options["pr-body"];
+  if (options["event-path"]) {
+    const event = JSON.parse(fs.readFileSync(options["event-path"], "utf8"));
+    return event.pull_request?.body ?? "";
+  }
+  throw new Error("either --pr-body or --event-path is required");
+}
+
+function resolveChangedFiles(options) {
+  if (options["changed-file"]) return asArray(options["changed-file"]);
+  if (options["base-sha"] && options["head-sha"]) {
+    const result = spawnSync("git", ["diff", "--name-only", options["base-sha"], options["head-sha"]], { encoding: "utf8" });
+    if (result.status !== 0) throw new Error((result.stderr || result.stdout || "git diff failed").trim());
+    return result.stdout.split("\n").map((line) => line.trim()).filter(Boolean);
+  }
+  throw new Error("either --changed-file or both --base-sha and --head-sha are required");
+}
+
+function currentBranch() {
+  return gitOutput(["branch", "--show-current"]) ?? "";
+}
+
+function inferBaseRepo() {
+  const upstream = parseGithubRemote(gitOutput(["remote", "get-url", "upstream"]));
+  return upstream ? `${upstream.owner}/${upstream.repo}` : null;
+}
+
+function gitOutput(args) {
+  const result = spawnSync("git", args, { encoding: "utf8" });
+  if (result.status !== 0) return null;
+  return result.stdout.trim();
+}
+
+function parseGithubRemote(remote) {
+  if (!remote) return null;
+  const match = remote.match(GITHUB_REMOTE_PATTERN);
+  if (!match) return null;
+  return { owner: match[1], repo: match[2] };
+}
+
+function parseIssueFromBranch(branch) {
+  const match = branch.match(/\bissue-(\d+)\b/);
+  return match ? Number.parseInt(match[1], 10) : null;
+}
+
+function parseIssueNumber(value) {
+  return /^\d+$/.test(value) ? Number.parseInt(value, 10) : null;
+}
+
+function requireValue(value, message) {
+  if (!value) throw new Error(message);
+}
+
+function validateEnum(value, allowed, label) {
+  if (!allowed.includes(value)) {
+    throw new Error(`${label} must be one of: ${allowed.join(", ")}`);
+  }
+}
+
+function compare(left, right) {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function asArray(value) {
+  if (value === undefined) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main());
+}

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+git -C "$repo_root" config core.hooksPath .githooks
+chmod +x "$repo_root/.githooks/pre-push"
+
+echo "Configured git hooks path to .githooks"
+echo "Installed pre-push Codex review hook"

--- a/scripts/run-agent-preflight.sh
+++ b/scripts/run-agent-preflight.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if [[ "${CLAWPACK_PREFLIGHT_ACTIVE:-0}" == "1" ]]; then
+  echo "Agent preflight is already running; skipping recursive invocation."
+  exit 0
+fi
+export CLAWPACK_PREFLIGHT_ACTIVE=1
+
+REVIEW_FILE="${CLAWPACK_REVIEW_FILE:-$ROOT_DIR/.codex-review}"
+REVIEW_PROOF_FILE="${CLAWPACK_REVIEW_PROOF_FILE:-$ROOT_DIR/.codex-review-proof}"
+BASE_REF="${CLAWPACK_PREFLIGHT_BASE_REF:-upstream/main}"
+RUN_SMOKE="${CLAWPACK_PREFLIGHT_RUN_SMOKE:-0}"
+ENFORCE_ISSUE_STATE="${CLAWPACK_PREFLIGHT_ENFORCE_ISSUE_STATE:-0}"
+BUILD_COMMAND="${CLAWPACK_PREFLIGHT_BUILD_COMMAND:-npm run build}"
+TEST_COMMAND="${CLAWPACK_PREFLIGHT_TEST_COMMAND:-npm test}"
+SMOKE_COMMAND="${CLAWPACK_PREFLIGHT_SMOKE_COMMAND:-./scripts/run-cli-smoke.sh}"
+
+read_review_proof_value() {
+  local key="$1"
+  sed -n "s/^${key}=//p" "$REVIEW_PROOF_FILE" | head -n 1
+}
+
+check_review_note() {
+  if [[ ! -f "$REVIEW_FILE" ]]; then
+    echo "Preflight failed: missing .codex-review"
+    exit 1
+  fi
+
+  if ! grep -Eq '^scope reviewed:' "$REVIEW_FILE" \
+    || ! grep -Eq '^findings:' "$REVIEW_FILE" \
+    || ! grep -Eq '^remaining risks:' "$REVIEW_FILE"; then
+    echo "Preflight failed: .codex-review exists but is incomplete"
+    exit 1
+  fi
+
+  if grep -Fq 'native /review has not been run yet' "$REVIEW_FILE"; then
+    echo "Preflight failed: .codex-review still contains the checkpoint placeholder"
+    exit 1
+  fi
+}
+
+check_review_proof() {
+  local current_head proof_head proof_branch current_branch
+
+  if [[ ! -f "$REVIEW_PROOF_FILE" ]]; then
+    echo "Preflight failed: missing .codex-review-proof"
+    exit 1
+  fi
+
+  current_head="$(git rev-parse HEAD)"
+  current_branch="$(git branch --show-current)"
+  proof_head="$(read_review_proof_value head_sha)"
+  proof_branch="$(read_review_proof_value branch)"
+
+  if [[ -z "$proof_head" ]]; then
+    echo "Preflight failed: .codex-review-proof is missing head_sha"
+    exit 1
+  fi
+
+  if [[ "$proof_head" != "$current_head" ]]; then
+    echo "Preflight failed: .codex-review-proof does not match the current HEAD"
+    exit 1
+  fi
+
+  if [[ -n "$current_branch" ]] && [[ -n "$proof_branch" ]] && [[ "$proof_branch" != "$current_branch" ]]; then
+    echo "Preflight failed: .codex-review-proof was generated for a different branch"
+    exit 1
+  fi
+
+  if [[ "$REVIEW_FILE" -ot "$REVIEW_PROOF_FILE" ]]; then
+    echo "Preflight failed: .codex-review has not been updated since the latest review checkpoint"
+    exit 1
+  fi
+}
+
+check_branch_freshness() {
+  if [[ "${BYPASS_BRANCH_FRESHNESS_CHECK:-}" == "1" ]]; then
+    echo "Bypassing branch freshness check because BYPASS_BRANCH_FRESHNESS_CHECK=1"
+    return 0
+  fi
+
+  if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
+    echo "Skipping branch freshness check: base ref $BASE_REF is unavailable"
+    return 0
+  fi
+
+  if ! git merge-base --is-ancestor "$BASE_REF" HEAD; then
+    echo "Preflight failed: current branch does not contain the latest $BASE_REF"
+    exit 1
+  fi
+}
+
+check_issue_state() {
+  local output status
+  set +e
+  output="$(node "$ROOT_DIR/scripts/codex-pm.mjs" issue-state-check 2>&1)"
+  status=$?
+  set -e
+
+  if [[ $status -eq 0 ]]; then
+    echo "$output"
+    return 0
+  fi
+
+  echo "$output"
+  if [[ "$ENFORCE_ISSUE_STATE" == "1" ]]; then
+    exit 1
+  fi
+  echo "Continuing without enforced issue-state check. Set CLAWPACK_PREFLIGHT_ENFORCE_ISSUE_STATE=1 to require it."
+}
+
+run_local_pr_closure_check() {
+  local changed_files pr_body body_input=()
+
+  if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
+    echo "Skipping PR closure sync check: base ref $BASE_REF is unavailable"
+    return 0
+  fi
+
+  changed_files="$(git diff --name-only "$BASE_REF"...HEAD)"
+  if [[ -z "$changed_files" ]]; then
+    return 0
+  fi
+
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "Skipping PR closure sync check: gh is unavailable"
+    return 0
+  fi
+
+  pr_body="$(gh pr view --json body --jq .body 2>/dev/null || true)"
+  if [[ -z "$pr_body" ]]; then
+    echo "Skipping PR closure sync check: PR body is unavailable"
+    return 0
+  fi
+
+  while IFS= read -r changed_path; do
+    [[ -n "$changed_path" ]] || continue
+    body_input+=("--changed-file" "$changed_path")
+  done <<< "$changed_files"
+
+  node "$ROOT_DIR/scripts/codex-pm.mjs" verify-pr-closure-sync --pr-body "$pr_body" "${body_input[@]}"
+}
+
+echo "Running agent preflight in $ROOT_DIR"
+
+check_branch_freshness
+check_review_note
+check_review_proof
+check_issue_state
+
+echo "Running build"
+bash -lc "$BUILD_COMMAND"
+
+echo "Running tests"
+bash -lc "$TEST_COMMAND"
+
+echo "Running local PR closure sync check if PR body is available"
+run_local_pr_closure_check
+
+if [[ "$RUN_SMOKE" == "1" ]]; then
+  echo "Running CLI smoke validation"
+  bash -lc "$SMOKE_COMMAND"
+fi
+
+echo "Agent preflight passed."

--- a/scripts/run-cli-smoke.sh
+++ b/scripts/run-cli-smoke.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+TMP_DIR="$(mktemp -d)"
+SRC_DIR="$TMP_DIR/source"
+TARGET_DIR="$TMP_DIR/target"
+PACK_FILE="$TMP_DIR/sample.clawpack"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$SRC_DIR/workspace/skills/demo"
+cat >"$SRC_DIR/openclaw.json" <<'EOF'
+{
+  "agents": {
+    "defaults": {
+      "workspace": "./workspace"
+    },
+    "list": [
+      {
+        "id": "main",
+        "default": true,
+        "workspace": "./workspace"
+      }
+    ]
+  }
+}
+EOF
+cat >"$SRC_DIR/workspace/AGENTS.md" <<'EOF'
+# Demo Agent
+EOF
+cat >"$SRC_DIR/workspace/SOUL.md" <<'EOF'
+# Soul
+EOF
+cat >"$SRC_DIR/workspace/skills/demo/SKILL.md" <<'EOF'
+---
+name: demo
+description: demo skill
+---
+Use the demo skill.
+EOF
+
+npm run build >/dev/null
+
+node dist/cli.js inspect -p "$SRC_DIR" -f json >/dev/null
+node dist/cli.js export -p "$SRC_DIR" -o "$PACK_FILE" -t template -f json >/dev/null
+node dist/cli.js import "$PACK_FILE" -t "$TARGET_DIR" -f json >/dev/null
+
+VERIFY_OUTPUT="$(node dist/cli.js verify -p "$TARGET_DIR" -f json)"
+echo "$VERIFY_OUTPUT" | node -e '
+const data = JSON.parse(require("node:fs").readFileSync(0, "utf8"));
+if (!data.valid) process.exit(1);
+const hasManifestSchema = data.checks.some((check) => check.name === "manifest_schema");
+if (!hasManifestSchema) {
+  console.error("verify did not load persisted manifest");
+  process.exit(1);
+}
+'
+
+echo "CLI smoke passed."

--- a/scripts/run-codex-review-checkpoint.sh
+++ b/scripts/run-codex-review-checkpoint.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+REVIEW_FILE="${CLAWPACK_REVIEW_FILE:-$ROOT_DIR/.codex-review}"
+REVIEW_PROOF_FILE="${CLAWPACK_REVIEW_PROOF_FILE:-$ROOT_DIR/.codex-review-proof}"
+BASE_REF="${CLAWPACK_REVIEW_BASE_REF:-upstream/main}"
+BRANCH_NAME="$(git branch --show-current)"
+HEAD_SHA="$(git rev-parse HEAD)"
+
+build_diff_summary() {
+  local compare_ref="$1"
+  if git rev-parse --verify "$compare_ref" >/dev/null 2>&1; then
+    git diff --stat "$compare_ref"...HEAD
+    return 0
+  fi
+  if git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+    git diff --stat HEAD~1...HEAD
+    return 0
+  fi
+  echo "No comparison base available."
+}
+
+write_review_proof() {
+  cat >"$REVIEW_PROOF_FILE" <<EOF
+branch=${BRANCH_NAME:-detached-head}
+head_sha=$HEAD_SHA
+base_ref=$BASE_REF
+generated_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+EOF
+}
+
+if [[ ! -f "$REVIEW_FILE" ]]; then
+  diff_summary="$(build_diff_summary "$BASE_REF")"
+  cat >"$REVIEW_FILE" <<EOF
+scope reviewed: branch ${BRANCH_NAME:-detached-head}
+findings: no findings
+remaining risks: native /review has not been run yet
+
+diff summary:
+$diff_summary
+EOF
+  echo "Created review checkpoint template at $REVIEW_FILE"
+else
+  echo "Review checkpoint already exists at $REVIEW_FILE"
+fi
+
+write_review_proof
+echo "Refreshed review proof at $REVIEW_PROOF_FILE for HEAD $HEAD_SHA"
+
+cat <<EOF
+
+Next steps:
+1. In Codex, run the native /review command for the current branch changes.
+2. Update $REVIEW_FILE with the actual review scope, findings, and remaining risks after the review completes.
+3. Run ./scripts/run-agent-preflight.sh or push again after the review note is complete.
+EOF

--- a/src/core/packer.ts
+++ b/src/core/packer.ts
@@ -474,6 +474,10 @@ export async function importPack(options: ImportOptions): Promise<ImportResult> 
     }
 
     rebindWorkspaceConfig(targetDir, manifest, warnings);
+    fs.writeFileSync(
+      path.join(targetDir, ".clawpack-manifest.json"),
+      `${JSON.stringify(manifest, null, 2)}\n`
+    );
 
     let fileCount = 0;
     function countFiles(dir: string) {

--- a/test/cli-smoke.test.ts
+++ b/test/cli-smoke.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+
+describe("cli smoke script", () => {
+  it("validates the documented CLI path", () => {
+    const result = spawnSync("./scripts/run-cli-smoke.sh", [], {
+      cwd: "/workspace/02-projects/active/clawpack",
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("CLI smoke passed.");
+  }, 120000);
+});

--- a/test/codex-pm.test.ts
+++ b/test/codex-pm.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { main } from "../scripts/codex-pm.mjs";
+
+let tmpDir: string;
+let originalCwd: string;
+
+beforeEach(() => {
+  originalCwd = process.cwd();
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawpack-pm-"));
+  process.chdir(tmpDir);
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("codex-pm", () => {
+  it("initializes the pm workspace", () => {
+    expect(main(["init"])).toBe(0);
+    expect(fs.existsSync(path.join(tmpDir, ".codex", "pm", "tasks"))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, ".codex", "pm", "issue-state"))).toBe(true);
+  });
+
+  it("scaffolds tasks and renders issue and pr bodies", () => {
+    expect(main(["init"])).toBe(0);
+    expect(main([
+      "task-new",
+      "repository-harness",
+      "bootstrap",
+      "--title",
+      "Bootstrap harness",
+      "--issue",
+      "42",
+      "--labels",
+      "feature,test",
+    ])).toBe(0);
+
+    const taskPath = path.join(tmpDir, ".codex", "pm", "tasks", "repository-harness", "bootstrap.md");
+    let text = fs.readFileSync(taskPath, "utf8");
+    text = text.replace("## Context\n\n", "## Context\n\nNeed a local PM workflow.\n\n");
+    text = text.replace("## Deliverable\n\n", "## Deliverable\n\nAdd local PM scripts.\n\n");
+    text = text.replace("## Validation\n\n- \n\n", "## Validation\n\n- npm test\n\n");
+    fs.writeFileSync(taskPath, text, "utf8");
+
+    const issueLog: string[] = [];
+    const prLog: string[] = [];
+    expect(main(["issue-body", taskPath], { log: (value: string) => issueLog.push(value), error: () => undefined } as Console)).toBe(0);
+    expect(issueLog.join("\n")).toContain("Need a local PM workflow.");
+
+    expect(main(["pr-body", taskPath, "--issue", "42", "--tests", "npm test"], { log: (value: string) => prLog.push(value), error: () => undefined } as Console)).toBe(0);
+    expect(prLog.join("\n")).toContain("Closes #42");
+    expect(prLog.join("\n")).toContain("Validation:");
+  });
+
+  it("creates issue state and verifies closure sync", () => {
+    expect(main(["init"])).toBe(0);
+    expect(main([
+      "task-new",
+      "repository-harness",
+      "bootstrap",
+      "--title",
+      "Bootstrap harness",
+      "--issue",
+      "42",
+    ])).toBe(0);
+    const taskPath = path.join(tmpDir, ".codex", "pm", "tasks", "repository-harness", "bootstrap.md");
+
+    expect(main(["issue-state-init", taskPath])).toBe(0);
+    const statePath = path.join(tmpDir, ".codex", "pm", "issue-state", "42-bootstrap.md");
+    expect(fs.existsSync(statePath)).toBe(true);
+
+    expect(main(["set-status", taskPath, "done"])).toBe(0);
+    expect(main([
+      "verify-pr-closure-sync",
+      "--pr-body",
+      "Closes #42",
+      "--changed-file",
+      path.relative(tmpDir, taskPath),
+    ])).toBe(0);
+  });
+});

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -348,6 +348,7 @@ describe("export + import", () => {
     expect(importResult.manifest.harness.intent).toBe("agent-runtime-environment");
     expect(fs.existsSync(path.join(targetDir, "workspace", "AGENTS.md"))).toBe(true);
     expect(fs.existsSync(path.join(targetDir, "openclaw.json"))).toBe(true);
+    expect(fs.existsSync(path.join(targetDir, ".clawpack-manifest.json"))).toBe(true);
   });
 
   it("imports instance pack preserving agent directory structure", async () => {

--- a/test/pre-push-hook.test.ts
+++ b/test/pre-push-hook.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+function git(cwd: string, ...args: string[]) {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(result.stderr || result.stdout);
+  }
+  return result.stdout.trim();
+}
+
+function prepareRepo() {
+  const repo = fs.mkdtempSync(path.join(os.tmpdir(), "clawpack-hook-"));
+  git(repo, "init", "-b", "main");
+  git(repo, "config", "user.name", "Test User");
+  git(repo, "config", "user.email", "test@example.com");
+  git(repo, "remote", "add", "origin", "git@github.com:test/clawpack.git");
+
+  const sourceRoot = "/workspace/02-projects/active/clawpack";
+  fs.mkdirSync(path.join(repo, ".githooks"), { recursive: true });
+  fs.mkdirSync(path.join(repo, "scripts"), { recursive: true });
+  fs.copyFileSync(path.join(sourceRoot, ".githooks", "pre-push"), path.join(repo, ".githooks", "pre-push"));
+  fs.copyFileSync(path.join(sourceRoot, "scripts", "codex-pm.mjs"), path.join(repo, "scripts", "codex-pm.mjs"));
+  fs.chmodSync(path.join(repo, ".githooks", "pre-push"), 0o755);
+
+  fs.mkdirSync(path.join(repo, ".codex", "pm", "tasks", "repository-harness"), { recursive: true });
+  fs.writeFileSync(path.join(repo, ".codex", "pm", "tasks", "repository-harness", "bootstrap.md"), `---
+type: task
+epic: repository-harness
+slug: bootstrap
+title: Bootstrap harness
+status: in_progress
+task_type: implementation
+issue: 42
+---
+
+## Context
+
+Test task.
+`, "utf8");
+
+  fs.writeFileSync(path.join(repo, "README.md"), "base\n", "utf8");
+  git(repo, "add", ".");
+  git(repo, "commit", "-m", "base");
+  git(repo, "checkout", "-b", "issue-42-bootstrap");
+  fs.appendFileSync(path.join(repo, ".codex", "pm", "tasks", "repository-harness", "bootstrap.md"), "\nMore body.\n");
+  git(repo, "add", ".codex/pm/tasks/repository-harness/bootstrap.md");
+  git(repo, "commit", "-m", "update task");
+
+  const headSha = git(repo, "rev-parse", "HEAD");
+  fs.writeFileSync(path.join(repo, ".codex-review-proof"), `branch=issue-42-bootstrap\nhead_sha=${headSha}\nbase_ref=main\ngenerated_at=2026-03-12T00:00:00Z\n`, "utf8");
+  fs.writeFileSync(path.join(repo, ".codex-review"), "scope reviewed: hook\nfindings: no findings\nremaining risks: local-only validation\n", "utf8");
+
+  const binDir = path.join(repo, "bin");
+  fs.mkdirSync(binDir);
+  fs.writeFileSync(path.join(binDir, "gh"), `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  echo '[]'
+  exit 0
+fi
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  printf 'Closes #42'
+  exit 0
+fi
+echo "unexpected gh invocation: $*" >&2
+exit 1
+`, "utf8");
+  fs.chmodSync(path.join(binDir, "gh"), 0o755);
+
+  return { repo, binDir };
+}
+
+describe("pre-push hook", () => {
+  it("blocks missing review proof", () => {
+    const { repo, binDir } = prepareRepo();
+    fs.rmSync(path.join(repo, ".codex-review-proof"));
+
+    const result = spawnSync(path.join(repo, ".githooks", "pre-push"), [], {
+      cwd: repo,
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH}`,
+        BYPASS_BRANCH_FRESHNESS_CHECK: "1",
+        CLAWPACK_BASE_REF: "main",
+      },
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("missing .codex-review-proof");
+    fs.rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("blocks closure sync mismatch when task is not done", () => {
+    const { repo, binDir } = prepareRepo();
+
+    const result = spawnSync(path.join(repo, ".githooks", "pre-push"), [], {
+      cwd: repo,
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH}`,
+        BYPASS_BRANCH_FRESHNESS_CHECK: "1",
+        CLAWPACK_BASE_REF: "main",
+      },
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("matching task file is not marked done");
+    fs.rmSync(repo, { recursive: true, force: true });
+  });
+});

--- a/test/preflight-script.test.ts
+++ b/test/preflight-script.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+describe("run-agent-preflight.sh", () => {
+  it("fails without a review note", () => {
+    const repoRoot = "/workspace/02-projects/active/clawpack";
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawpack-preflight-"));
+    const result = spawnSync("./scripts/run-agent-preflight.sh", [], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        CLAWPACK_REVIEW_FILE: path.join(tmpDir, ".codex-review"),
+        CLAWPACK_REVIEW_PROOF_FILE: path.join(tmpDir, ".codex-review-proof"),
+        CLAWPACK_PREFLIGHT_BASE_REF: "HEAD",
+        CLAWPACK_PREFLIGHT_ACTIVE: "0",
+      },
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("missing .codex-review");
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("passes with overridden build and test commands", () => {
+    const repoRoot = "/workspace/02-projects/active/clawpack";
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawpack-preflight-"));
+    const branch = spawnSync("git", ["branch", "--show-current"], { cwd: repoRoot, encoding: "utf8" }).stdout.trim();
+    const headSha = spawnSync("git", ["rev-parse", "HEAD"], { cwd: repoRoot, encoding: "utf8" }).stdout.trim();
+
+    fs.writeFileSync(path.join(tmpDir, ".codex-review"), "scope reviewed: preflight\nfindings: no findings\nremaining risks: smoke skipped\n", "utf8");
+    fs.writeFileSync(path.join(tmpDir, ".codex-review-proof"), `branch=${branch}\nhead_sha=${headSha}\nbase_ref=HEAD\ngenerated_at=2026-03-12T00:00:00Z\n`, "utf8");
+
+    const result = spawnSync("./scripts/run-agent-preflight.sh", [], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        CLAWPACK_REVIEW_FILE: path.join(tmpDir, ".codex-review"),
+        CLAWPACK_REVIEW_PROOF_FILE: path.join(tmpDir, ".codex-review-proof"),
+        CLAWPACK_PREFLIGHT_BASE_REF: "HEAD",
+        CLAWPACK_PREFLIGHT_BUILD_COMMAND: "true",
+        CLAWPACK_PREFLIGHT_TEST_COMMAND: "true",
+        CLAWPACK_PREFLIGHT_ACTIVE: "0",
+      },
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Agent preflight passed.");
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
Closes #3

Add local PM tooling, hook/preflight scripts, and a standard CLI smoke validation path without making ClawPack depend on OpenPrecedent.

Implementation notes:
Use Node-based local scripts so the harness remains self-contained for a TypeScript CLI repository.

Validation:
- `npm run build`
- `npm test`
- `./scripts/run-cli-smoke.sh`