### PR TITLE
Harden local harness guardrails for everyday use

### DIFF
--- a/.codex/pm/epics/repository-harness.md
+++ b/.codex/pm/epics/repository-harness.md
@@ -24,9 +24,12 @@ ClawPack gains a practical local harness for disciplined development and validat
 
 ## Child Issues
 
-- bootstrap ccpm-codex and local guardrails
+- #3 bootstrap ccpm-codex and local guardrails
+- #5 harden local harness guardrails for everyday use
+- #6 document repository harness governance and daily workflow
+- #7 expand CLI integration validation for the pack lifecycle
+- #8 reconcile README guarantees with actual CLI behavior
 
 ## Notes
 
 This epic intentionally excludes research-only workflows.
-

--- a/.codex/pm/issue-state/5-harden-local-guardrails.md
+++ b/.codex/pm/issue-state/5-harden-local-guardrails.md
@@ -1,0 +1,32 @@
+---
+type: issue_state
+issue: 5
+task: .codex/pm/tasks/repository-harness/harden-local-guardrails.md
+title: Harden local harness guardrails for everyday use
+status: done
+---
+
+## Summary
+
+Harden the everyday local harness path by reducing Git noise from review artifacts and by extending pre-push guardrail coverage for stale proof and merged branch behavior.
+
+## Validated Facts
+
+- `.codex-review` and `.codex-review-proof` were showing up as ordinary untracked files before being added to `.gitignore`.
+- The existing pre-push tests covered missing proof and closure-sync mismatch, but not stale proof or merged-branch reuse.
+- The merged-branch reuse test needs an `upstream` remote in the fixture repo because the hook derives the target repo from `upstream`.
+
+## Open Questions
+
+- Should future harness work add a dedicated policy doc for local-only workflow artifacts beyond this brief note in tooling setup?
+
+## Next Steps
+
+- use the updated guardrail coverage as baseline for later harness tasks
+- keep the future governance and CLI-validation work split into their own issue-scoped branches
+
+## Artifacts
+
+- `.gitignore`
+- `test/pre-push-hook.test.ts`
+- `docs/engineering/tooling-setup.md`

--- a/.codex/pm/tasks/repository-harness/document-harness-governance.md
+++ b/.codex/pm/tasks/repository-harness/document-harness-governance.md
@@ -1,0 +1,38 @@
+---
+type: task
+epic: repository-harness
+slug: document-harness-governance
+title: Document repository harness governance and daily workflow
+status: backlog
+task_type: docs
+labels: docs,tooling
+issue: 6
+---
+
+## Context
+
+The repository now has issue-task-PR tooling, hooks, preflight, and smoke validation, but the contributor-facing daily workflow is still fragmented across files.
+
+## Deliverable
+
+Add clear repository governance and daily workflow documentation for using the ClawPack harness from issue start to merged PR.
+
+## Scope
+
+- document one-issue-per-branch and one-issue-per-PR rules
+- document when to initialize issue-state, run preflight, and run CLI smoke
+- document which local artifacts are temporary and should not be committed
+
+## Acceptance Criteria
+
+- one clear daily harness workflow is documented
+- the guidance matches the repository scripts and hooks
+- the docs stay ClawPack-specific and avoid OpenPrecedent research framing
+
+## Validation
+
+- manual doc review against repository scripts
+
+## Implementation Notes
+
+Prefer one concise governance path rather than scattering the same rules across multiple docs.

--- a/.codex/pm/tasks/repository-harness/expand-cli-integration-validation.md
+++ b/.codex/pm/tasks/repository-harness/expand-cli-integration-validation.md
@@ -1,0 +1,39 @@
+---
+type: task
+epic: repository-harness
+slug: expand-cli-integration-validation
+title: Expand CLI integration validation for the pack lifecycle
+status: backlog
+task_type: implementation
+labels: feature,test
+issue: 7
+---
+
+## Context
+
+ClawPack now has a basic CLI smoke path, but the command-level validation matrix remains thinner than the public CLI surface.
+
+## Deliverable
+
+Expand command-level validation for `inspect`, `export`, `import`, and `verify`, with emphasis on real CLI behavior rather than direct module invocation.
+
+## Scope
+
+- add command-level integration coverage for template and instance flows
+- add user-visible error-path coverage where behavior matters
+- complement the existing smoke path instead of duplicating it
+
+## Acceptance Criteria
+
+- key user-facing CLI paths are exercised at the command layer
+- failures are asserted through exit status and output behavior
+- the command-level matrix is clearly distinct from module-level tests
+
+## Validation
+
+- `npm test`
+- targeted CLI integration runs as added by the task
+
+## Implementation Notes
+
+Focus on the public contract of the shipped `clawpack` CLI.

--- a/.codex/pm/tasks/repository-harness/harden-local-guardrails.md
+++ b/.codex/pm/tasks/repository-harness/harden-local-guardrails.md
@@ -1,0 +1,40 @@
+---
+type: task
+epic: repository-harness
+slug: harden-local-guardrails
+title: Harden local harness guardrails for everyday use
+status: done
+task_type: implementation
+labels: feature,tooling,test
+issue: 5
+state_path: .codex/pm/issue-state/5-harden-local-guardrails.md
+---
+
+## Context
+
+The initial harness bootstrap is merged, but the day-to-day local workflow still needs a small hardening pass so review artifacts and guardrail behavior are cleaner in normal use.
+
+## Deliverable
+
+Tighten the local harness by ignoring review artifacts in Git and extending guardrail coverage for merged-branch and stale-proof behavior.
+
+## Scope
+
+- ignore `.codex-review` and `.codex-review-proof` in Git
+- extend pre-push guardrail coverage for merged branch reuse
+- extend pre-push guardrail coverage for stale review proof mismatch
+
+## Acceptance Criteria
+
+- local review artifacts do not show up as normal untracked files
+- pre-push tests cover merged branch reuse and stale proof mismatch
+- local harness docs remain accurate after the changes
+
+## Validation
+
+- `npm test`
+- `./scripts/run-agent-preflight.sh`
+
+## Implementation Notes
+
+Keep the work in ClawPack's repository-local harness; do not pull in extra OpenPrecedent-specific workflow layers.

--- a/.codex/pm/tasks/repository-harness/reconcile-readme-and-cli-contract.md
+++ b/.codex/pm/tasks/repository-harness/reconcile-readme-and-cli-contract.md
@@ -1,0 +1,39 @@
+---
+type: task
+epic: repository-harness
+slug: reconcile-readme-and-cli-contract
+title: Reconcile README guarantees with actual CLI behavior
+status: backlog
+task_type: docs
+labels: docs,test
+issue: 8
+---
+
+## Context
+
+The current README still makes some stronger claims than the implementation actually guarantees, especially around verify semantics and pack risk expectations.
+
+## Deliverable
+
+Update README and related docs so they match the implemented CLI semantics and the validation coverage that actually exists.
+
+## Scope
+
+- compare README workflow claims against current CLI behavior
+- tighten wording where implementation is intentionally narrower
+- add or adjust tests when documentation changes should stay locked in
+
+## Acceptance Criteria
+
+- the README no longer overclaims verify or risk-level behavior
+- user-visible contract clarifications have matching validation coverage
+- future harness and product work can rely on the docs as a truthful baseline
+
+## Validation
+
+- doc review against current command behavior
+- `npm test` for any linked validation coverage
+
+## Implementation Notes
+
+This is a ClawPack-specific correctness task, not a generic harness export task.

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ Thumbs.db
 # Environment
 .env
 .env.*
+.codex-review
+.codex-review-proof
 
 # Coverage
 coverage/

--- a/docs/engineering/tooling-setup.md
+++ b/docs/engineering/tooling-setup.md
@@ -17,6 +17,7 @@ To enable the local hook:
 ```
 
 After that, each push requires both a `.codex-review` file and a current `.codex-review-proof` file in the repository root unless you explicitly bypass the hook. The hook also expects your branch to contain the latest `upstream/main` by default.
+These two files are local review artifacts for the current branch and should stay untracked in normal development.
 
 ## Codex Review Hook
 

--- a/test/pre-push-hook.test.ts
+++ b/test/pre-push-hook.test.ts
@@ -18,6 +18,7 @@ function prepareRepo() {
   git(repo, "config", "user.name", "Test User");
   git(repo, "config", "user.email", "test@example.com");
   git(repo, "remote", "add", "origin", "git@github.com:test/clawpack.git");
+  git(repo, "remote", "add", "upstream", "https://github.com/Mrxuexi/clawpack.git");
 
   const sourceRoot = "/workspace/02-projects/active/clawpack";
   fs.mkdirSync(path.join(repo, ".githooks"), { recursive: true });
@@ -111,6 +112,66 @@ describe("pre-push hook", () => {
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("matching task file is not marked done");
+    fs.rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("blocks stale review proof mismatches", () => {
+    const { repo, binDir } = prepareRepo();
+    fs.writeFileSync(
+      path.join(repo, ".codex-review-proof"),
+      "branch=issue-42-bootstrap\nhead_sha=deadbeef\nbase_ref=main\ngenerated_at=2026-03-12T00:00:00Z\n",
+      "utf8"
+    );
+
+    const result = spawnSync(path.join(repo, ".githooks", "pre-push"), [], {
+      cwd: repo,
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH}`,
+        BYPASS_BRANCH_FRESHNESS_CHECK: "1",
+        CLAWPACK_BASE_REF: "main",
+      },
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("does not match the current HEAD");
+    fs.rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("blocks reusing a branch whose PR already merged", () => {
+    const { repo, binDir } = prepareRepo();
+    fs.writeFileSync(path.join(binDir, "gh"), `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  echo '[{"number":4,"url":"https://github.com/Mrxuexi/clawpack/pull/4"}]'
+  exit 0
+fi
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  printf 'Closes #42'
+  exit 0
+fi
+echo "unexpected gh invocation: $*" >&2
+exit 1
+`, "utf8");
+    fs.chmodSync(path.join(binDir, "gh"), 0o755);
+    const taskPath = path.join(repo, ".codex", "pm", "tasks", "repository-harness", "bootstrap.md");
+    const taskText = fs.readFileSync(taskPath, "utf8").replace("status: in_progress", "status: done");
+    fs.writeFileSync(taskPath, taskText, "utf8");
+
+    const result = spawnSync(path.join(repo, ".githooks", "pre-push"), [], {
+      cwd: repo,
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH}`,
+        BYPASS_BRANCH_FRESHNESS_CHECK: "1",
+        CLAWPACK_BASE_REF: "main",
+      },
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("already has a merged PR");
     fs.rmSync(repo, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
Closes #5

Tighten the local harness by ignoring review artifacts in Git and extending guardrail coverage for merged-branch and stale-proof behavior.

Implementation notes:
Keep the work in ClawPack's repository-local harness; do not pull in extra OpenPrecedent-specific workflow layers.

Validation:
- `npm test`
- `./scripts/run-agent-preflight.sh`