### PR TITLE
Document repository harness governance and daily workflow

### DIFF
--- a/.codex/pm/issue-state/7-document-harness-governance.md
+++ b/.codex/pm/issue-state/7-document-harness-governance.md
@@ -1,0 +1,32 @@
+---
+type: issue_state
+issue: 7
+task: .codex/pm/tasks/repository-harness/document-harness-governance.md
+title: Document repository harness governance and daily workflow
+status: done
+---
+
+## Summary
+
+Consolidate the daily ClawPack harness workflow into a clear contributor-facing governance path and record the execution plan for issues `#6`, `#7`, and `#8`.
+
+## Validated Facts
+
+- ClawPack now has local PM workflow, hook, preflight, and CLI smoke scripts, but the daily usage rules are still spread across multiple files.
+- The local task twins for GitHub issues `#6` and `#7` were initially swapped and have been corrected before implementation continued.
+
+## Open Questions
+
+- How much governance detail belongs in `AGENTS.md` versus dedicated engineering docs?
+
+## Next Steps
+
+- continue `#6` on its own branch for command-level CLI validation
+- continue `#8` on its own branch for README and contract reconciliation
+
+## Artifacts
+
+- `.codex/pm/updates/`
+- `docs/engineering/repository-governance.md`
+- `docs/engineering/tooling-setup.md`
+- `AGENTS.md`

--- a/.codex/pm/tasks/repository-harness/document-harness-governance.md
+++ b/.codex/pm/tasks/repository-harness/document-harness-governance.md
@@ -3,10 +3,11 @@ type: task
 epic: repository-harness
 slug: document-harness-governance
 title: Document repository harness governance and daily workflow
-status: backlog
+status: done
 task_type: docs
 labels: docs,tooling
-issue: 6
+issue: 7
+state_path: .codex/pm/issue-state/7-document-harness-governance.md
 ---
 
 ## Context

--- a/.codex/pm/tasks/repository-harness/expand-cli-integration-validation.md
+++ b/.codex/pm/tasks/repository-harness/expand-cli-integration-validation.md
@@ -6,7 +6,7 @@ title: Expand CLI integration validation for the pack lifecycle
 status: backlog
 task_type: implementation
 labels: feature,test
-issue: 7
+issue: 6
 ---
 
 ## Context

--- a/.codex/pm/updates/2026-03-12-harness-todolist.md
+++ b/.codex/pm/updates/2026-03-12-harness-todolist.md
@@ -1,0 +1,21 @@
+---
+type: update
+title: Harness follow-up todolist for issues 6, 7, and 8
+date: 2026-03-12
+---
+
+## Goal
+
+Track the remaining harness follow-up work that should be completed as three separate issue-scoped pull requests for review.
+
+## Todo
+
+- [x] `#7` Document repository harness governance and daily workflow
+- [ ] `#6` Expand CLI integration validation for the pack lifecycle
+- [ ] `#8` Reconcile README guarantees with actual CLI behavior
+
+## Notes
+
+- Keep one issue per branch and one issue per PR.
+- Do not mix `#6`, `#7`, and `#8` implementation changes into the same pull request.
+- Use the local PM workflow, review checkpoint, preflight, and smoke validation where applicable.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ Harness and workflow support lives in:
 - `.codex/pm/` — local PRD/epic/task/state documents
 - `.githooks/pre-push` — local review/proof/closure guardrail
 - `scripts/` — PM, review checkpoint, preflight, and CLI smoke commands
+- `docs/engineering/repository-governance.md` — contributor-facing daily harness workflow
 
 ## Key Concepts
 
@@ -65,5 +66,9 @@ Harness and workflow support lives in:
 - Archive handling uses the `tar` npm package
 - Import paths in source use `.js` extensions (ESM convention)
 - Use `node scripts/codex-pm.mjs` for repository-local task, issue-state, and PR-body workflows instead of ad hoc notes
+- Keep one issue per branch and one issue per PR
+- Start each issue branch from the latest `upstream/main`
+- Do not keep working on a branch after its PR has merged
 - Before push, prefer `./scripts/run-codex-review-checkpoint.sh` and `./scripts/run-agent-preflight.sh`
+- Run `./scripts/run-cli-smoke.sh` when a change affects the documented command path or import/export/verify behavior
 - Any repeated workflow mistake that should have been blocked locally should be treated as a harness gap and fixed through the local guardrail layer

--- a/docs/engineering/repository-governance.md
+++ b/docs/engineering/repository-governance.md
@@ -1,0 +1,87 @@
+# Repository Governance
+
+## Purpose
+
+ClawPack uses a repository-local harness so development work stays issue-scoped, reviewable, and repeatable.
+
+This document explains the normal daily workflow for contributors and coding agents working in this repository.
+
+## Core Rules
+
+- One issue per branch.
+- One issue per pull request.
+- Always branch from the latest `upstream/main`.
+- Do not continue work on a branch whose pull request has already merged.
+- Keep local task twins under `.codex/pm/tasks/` in sync with the GitHub issue they represent.
+
+## Daily Workflow
+
+1. Start from the latest `upstream/main`.
+2. Create or confirm the matching GitHub issue.
+3. Create or update the local task twin under `.codex/pm/tasks/`.
+4. Move the task to `in_progress`.
+5. Initialize issue-state if the work may span multiple sessions.
+6. Implement the issue on its dedicated branch only.
+7. Run the local review checkpoint.
+8. Update `.codex-review` with real findings and remaining risks.
+9. Run local preflight.
+10. Open one pull request that closes the matching issue.
+
+## Local PM Workflow
+
+Use the repository-local PM commands rather than ad hoc notes:
+
+```bash
+node scripts/codex-pm.mjs init
+node scripts/codex-pm.mjs task-new <epic> <slug> --title "<title>" --issue <n>
+node scripts/codex-pm.mjs set-status <task-path> in_progress
+node scripts/codex-pm.mjs issue-state-init <task-path>
+node scripts/codex-pm.mjs pr-body <task-path> --issue <n>
+```
+
+The task file is the local twin of the GitHub issue. For longer work, the issue-state file holds validated facts, open questions, next steps, and artifacts so later sessions do not need to reconstruct them.
+
+## Review And Preflight
+
+Before push, use:
+
+```bash
+./scripts/run-codex-review-checkpoint.sh
+./scripts/run-agent-preflight.sh
+```
+
+The review checkpoint creates or refreshes:
+
+- `.codex-review`
+- `.codex-review-proof`
+
+These files are local branch artifacts and should remain untracked in normal development.
+
+Preflight checks:
+
+- branch freshness against `upstream/main`
+- review note and proof coherence
+- issue-state readiness
+- build and test execution
+- local PR closure sync when the current PR body is available through `gh`
+
+## When To Run Smoke Validation
+
+Run:
+
+```bash
+./scripts/run-cli-smoke.sh
+```
+
+when a change affects the documented command path or import/export/verify behavior in a way that should be confirmed end-to-end.
+
+For routine documentation-only changes, smoke validation is usually unnecessary unless the docs claim a behavior change.
+
+## Temporary Local Artifacts
+
+The following files are local-only and should not normally be committed:
+
+- `.codex-review`
+- `.codex-review-proof`
+
+Everything under `.codex/pm/` is repository-local workflow state and may be committed when it is part of the tracked issue/task history.

--- a/docs/engineering/tooling-setup.md
+++ b/docs/engineering/tooling-setup.md
@@ -10,6 +10,10 @@ The repository now includes:
 - `scripts/run-cli-smoke.sh` for the standard CLI smoke validation path
 - `node scripts/codex-pm.mjs issue-state-init <task-path>` for preserving issue-scoped state across longer work
 
+For the full daily workflow and repository rules, see:
+
+- `docs/engineering/repository-governance.md`
+
 To enable the local hook:
 
 ```bash
@@ -44,6 +48,13 @@ For the standard local readiness pass before push, run:
 ```
 
 This checks the local review note, review proof, issue-state, build, tests, and local PR closure sync when `gh` can resolve the current PR body.
+
+A normal issue-scoped path is:
+
+1. `./scripts/run-codex-review-checkpoint.sh`
+2. update `.codex-review`
+3. `./scripts/run-agent-preflight.sh`
+4. open the PR generated from the matching local task twin
 
 Set `CLAWPACK_PREFLIGHT_RUN_SMOKE=1` if you also want the CLI smoke path included in the same pass.
 


### PR DESCRIPTION
Closes #7

Add clear repository governance and daily workflow documentation for using the ClawPack harness from issue start to merged PR.

Implementation notes:
Prefer one concise governance path rather than scattering the same rules across multiple docs.

Validation:
- manual doc review against repository scripts