### PR TITLE
Reconcile README guarantees with actual CLI behavior

### DIFF
--- a/.codex/pm/issue-state/8-reconcile-readme-and-cli-contract.md
+++ b/.codex/pm/issue-state/8-reconcile-readme-and-cli-contract.md
@@ -1,0 +1,27 @@
+---
+type: issue_state
+issue: 8
+task: .codex/pm/tasks/repository-harness/reconcile-readme-and-cli-contract.md
+title: Reconcile README guarantees with actual CLI behavior
+status: done
+---
+
+## Summary
+
+Record the current working state for this issue so later sessions do not have to rediscover it.
+
+## Validated Facts
+
+-
+
+## Open Questions
+
+-
+
+## Next Steps
+
+- keep the README wording aligned with future CLI changes and command-level validation
+
+## Artifacts
+
+-

--- a/.codex/pm/tasks/repository-harness/reconcile-readme-and-cli-contract.md
+++ b/.codex/pm/tasks/repository-harness/reconcile-readme-and-cli-contract.md
@@ -3,10 +3,11 @@ type: task
 epic: repository-harness
 slug: reconcile-readme-and-cli-contract
 title: Reconcile README guarantees with actual CLI behavior
-status: backlog
+status: done
 task_type: docs
 labels: docs,test
 issue: 8
+state_path: .codex/pm/issue-state/8-reconcile-readme-and-cli-contract.md
 ---
 
 ## Context

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ Harness and workflow support lives in:
 
 ## Key Concepts
 
-- **PackType**: `"template"` (excludes secrets, safe to share) vs `"instance"` (full migration, includes everything)
+- **PackType**: `"template"` (excludes known secrets and is share-oriented) vs `"instance"` (full migration, includes everything)
 - **RiskLevel**: `"safe-share"` | `"internal-only"` | `"trusted-migration-only"`
 - **State directory**: defaults to `~/.openclaw`, auto-detected from several known names
 

--- a/README.md
+++ b/README.md
@@ -161,15 +161,15 @@ clawpack import my-agent.clawpack -t ./target  # custom target
 
 ### `clawpack verify`
 
-Verify an imported instance is structurally complete and usable.
+Verify an imported instance is structurally complete and basically readable. When a persisted import manifest is present, `verify` also checks manifest-related expectations.
 
 ```
  ~/.openclaw/
  ├── config/  ✓        clawpack verify
  ├── workspace/  ✓   ─────────────────▶   All checks passed  ✓
  ├── AGENTS.md  ✓                          - directories exist
- └── state/  ✓                             - manifest valid
-                                           - workspace intact
+ └── state/  ✓                             - workspace intact
+                                           - manifest checks (if imported manifest is available)
 ```
 
 ```bash
@@ -202,10 +202,10 @@ clawpack verify -p /path/to/dir  # custom path
 
 | Type | Use Case | Includes | Risk Level |
 |------|----------|----------|------------|
-| **template** | Share & reuse | Workspace, non-sensitive config | `safe-share` |
-| **instance** | Full migration | Config, workspace, state, credentials | `trusted-migration-only` |
+| **template** | Share & reuse | Workspace, non-sensitive config | Share-oriented; manifest risk is still derived from detected source sensitivity |
+| **instance** | Full migration | Config, workspace, state, credentials | Usually `trusted-migration-only` when credentials or state are present |
 
-Template packs automatically exclude credentials, sessions, memory databases, and `.env` files.
+Template packs automatically exclude credentials, sessions, memory databases, and `.env` files, but the manifest still records what sensitive indicators were detected in the source instance.
 
 ## Package Format
 
@@ -254,6 +254,8 @@ my-agent.clawpack (gzipped tar)
 | `safe-share` | No sensitive data, safe to distribute |
 | `internal-only` | May contain non-critical config, share within team |
 | `trusted-migration-only` | Contains credentials/state, trusted environments only |
+
+Risk level is assessed from the exported manifest metadata and detected source sensitivity, not only from the chosen pack type.
 
 ## Output Formats
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -159,15 +159,15 @@ clawpack import my-agent.clawpack -t ./target  # 指定目标目录
 
 ### `clawpack verify`
 
-检查导入后的实例是否结构完整、基础可用。
+检查导入后的实例是否结构完整、基础可读。如果目标目录里存在持久化的导入 manifest，`verify` 还会附带执行 manifest 相关检查。
 
 ```
  ~/.openclaw/
  ├── config/  ✓        clawpack verify
  ├── workspace/  ✓   ─────────────────▶   所有检查通过  ✓
  ├── AGENTS.md  ✓                          - 目录存在
- └── state/  ✓                             - manifest 有效
-                                           - 工作区完整
+ └── state/  ✓                             - 工作区完整
+                                           - manifest 检查（若导入 manifest 可用）
 ```
 
 ```bash
@@ -201,10 +201,10 @@ clawpack verify -p /path/to/dir  # 指定路径
 
 | 类型 | 用途 | 包含内容 | 风险等级 |
 |------|------|----------|----------|
-| **template** | 分享与复用 | 工作区、非敏感配置 | `safe-share` |
-| **instance** | 完整迁移 | 配置、工作区、状态、凭证 | `trusted-migration-only` |
+| **template** | 分享与复用 | 工作区、非敏感配置 | 面向分享；manifest 风险仍取决于源实例检测到的敏感信号 |
+| **instance** | 完整迁移 | 配置、工作区、状态、凭证 | 当包含凭证或状态时通常为 `trusted-migration-only` |
 
-模板包会自动排除凭证、会话数据、记忆数据库和 `.env` 文件。
+模板包会自动排除凭证、会话数据、记忆数据库和 `.env` 文件，但 manifest 仍会记录源实例中检测到的敏感信号。
 
 ## 包格式
 
@@ -253,6 +253,8 @@ my-agent.clawpack (gzip 压缩的 tar)
 | `safe-share` | 无敏感数据，可安全分发 |
 | `internal-only` | 可能包含非关键配置，仅限团队内部分享 |
 | `trusted-migration-only` | 包含凭证或状态数据，仅限受信任环境导入 |
+
+风险等级来自导出 manifest 中记录的检测结果与敏感信号，并不只由 `template` / `instance` 类型本身决定。
 
 ## 输出格式
 


### PR DESCRIPTION
Closes #8

Update README and related docs so they match the implemented CLI semantics and the validation coverage that actually exists.

Implementation notes:
This is a ClawPack-specific correctness task, not a generic harness export task.

Validation:
- doc review against current command behavior
- `npm test` for any linked validation coverage