### PR TITLE
Define ClawPack product foundation and MVP-to-1.0 architecture

### DIFF
--- a/.codex/pm/epics/product-direction.md
+++ b/.codex/pm/epics/product-direction.md
@@ -1,0 +1,33 @@
+---
+type: epic
+slug: product-direction
+title: Product Direction
+status: backlog
+prd: harness-image-foundation
+---
+
+## Outcome
+
+ClawPack gains a coherent product definition that connects the current OpenClaw-first implementation to the broader harness image vision.
+
+
+## Scope
+
+- product foundation
+- MVP and 1.0 roadmap framing
+- target architecture alignment
+
+## Acceptance Criteria
+
+- the terminal product goal is explicit
+- the core product axis is explicit
+- MVP and 1.0 boundaries are documented
+- the repository documents architecture continuity between MVP and 1.0
+
+## Child Issues
+
+- #13 define ClawPack product foundation and architecture-aligned MVP/1.0 roadmap
+
+## Notes
+
+This epic is about product definition and architectural continuity, not about adding new runtime features immediately.

--- a/.codex/pm/issue-state/13-define-product-foundation-roadmap.md
+++ b/.codex/pm/issue-state/13-define-product-foundation-roadmap.md
@@ -1,0 +1,32 @@
+---
+type: issue_state
+issue: 13
+task: .codex/pm/tasks/product-direction/define-product-foundation-roadmap.md
+title: Define ClawPack product foundation and architecture-aligned MVP/1.0 roadmap
+status: in_progress
+---
+
+## Summary
+
+Capture the product-definition work that reframes ClawPack from an OpenClaw-first packaging CLI into a broader harness image system with an architecture-consistent MVP and 1.0 path.
+
+## Validated Facts
+
+- the repository already has an implemented OpenClaw-first `inspect -> export -> import -> verify` loop
+- the current docs do not yet fully unify that implementation with the broader harness image direction
+- the product direction should preserve OpenClaw as the first adapter while removing OpenClaw as the conceptual product boundary
+
+## Open Questions
+
+- how much of the broader harness-image framing should be surfaced in the top-level README vs deeper docs
+
+## Next Steps
+
+- none; ready for review
+
+## Artifacts
+
+- issue #13
+- `docs/prds/0002-product-foundation.md`
+- `docs/prds/0003-roadmap-mvp-to-v1.md`
+- `docs/architecture/0001-harness-image-architecture.md`

--- a/.codex/pm/prds/harness-image-foundation.md
+++ b/.codex/pm/prds/harness-image-foundation.md
@@ -1,0 +1,38 @@
+---
+type: prd
+slug: harness-image-foundation
+title: ClawPack Harness Image Product Foundation
+status: draft
+---
+
+## Summary
+
+Define ClawPack as a harness image system for agent runtime environments, with OpenClaw as the first production adapter.
+
+
+## Problem
+
+The repository has a clear OpenClaw-first `v0.1`, but it does not yet unify that starting point with the broader product goal of packaging reusable harness environments.
+
+
+## Goals
+
+- define the terminal product goal and core product axis
+- define the product language for harnesses, harness images, and layers
+- define MVP and 1.0 as one continuous architecture path
+
+## Non-Goals
+
+- finalize every future adapter
+- design a hosted marketplace
+- require a SaaS control plane for 1.0
+
+## Success Criteria
+
+- the repository has canonical docs for product foundation, roadmap, and target architecture
+- MVP and 1.0 are framed as one evolvable architecture
+- the old OpenClaw-first v0.1 doc remains as historical context, not the only product definition
+
+## Dependencies
+
+- existing `v0.1` implementation and docs

--- a/.codex/pm/tasks/product-direction/define-product-foundation-roadmap.md
+++ b/.codex/pm/tasks/product-direction/define-product-foundation-roadmap.md
@@ -1,0 +1,44 @@
+---
+type: task
+epic: product-direction
+slug: define-product-foundation-roadmap
+title: Define ClawPack product foundation and architecture-aligned MVP/1.0 roadmap
+status: in_progress
+task_type: implementation
+labels: docs,feature
+issue: 13
+state_path: .codex/pm/issue-state/13-define-product-foundation-roadmap.md
+---
+
+## Context
+
+The repository has an implemented OpenClaw-first `v0.1`, but it still needs a clearer product definition that connects the current work to the broader harness image direction.
+
+
+## Deliverable
+
+Add canonical product direction docs that define the terminal goal, core product axis, MVP boundary, 1.0 boundary, and the architecture relationship between them.
+
+
+## Scope
+
+- define the top-level product foundation
+- define MVP and 1.0 scope
+- define whether MVP and 1.0 share one architecture path
+- document the target architecture
+- update the existing docs to point to the new direction
+
+## Acceptance Criteria
+
+- the repository has a canonical product foundation document
+- the repository has a roadmap document for MVP to 1.0
+- the repository has a target architecture document
+- README, AGENTS, and the original `v0.1` PRD point readers to the new canonical docs
+
+## Validation
+
+- doc review against current implementation and roadmap intent
+
+## Implementation Notes
+
+Preserve the original `v0.1` PRD as a historical seed rather than rewriting history.

--- a/.codex/pm/updates/2026-03-12-product-direction-foundation.md
+++ b/.codex/pm/updates/2026-03-12-product-direction-foundation.md
@@ -1,0 +1,18 @@
+# 2026-03-12 Product Direction Foundation
+
+## Summary
+
+Captured the updated product framing that treats ClawPack as a harness image packaging system rather than only an OpenClaw packaging CLI.
+
+## Key Decisions
+
+- OpenClaw remains the first production adapter, not the product boundary.
+- The product's terminal goal is a layered harness image standard for agent runtime environments.
+- The MVP and 1.0 should be architecture-consistent.
+- The repository should document the 1.0-oriented architecture now, then implement the MVP subset of that architecture.
+
+## Artifacts
+
+- `docs/prds/0002-product-foundation.md`
+- `docs/prds/0003-roadmap-mvp-to-v1.md`
+- `docs/architecture/0001-harness-image-architecture.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,12 @@ This file provides guidance to AI coding agents (Claude Code, Codex, Cursor, etc
 
 ClawPack is an application-layer packaging and distribution CLI for OpenClaw agents. It packages an agent's workspace, config, state, and credentials into a portable `.clawpack` archive (gzipped tar containing `manifest.json`, `config/`, `workspace/`, `state/`, `reports/`).
 
+The broader product direction is documented in:
+
+- `docs/prds/0002-product-foundation.md`
+- `docs/prds/0003-roadmap-mvp-to-v1.md`
+- `docs/architecture/0001-harness-image-architecture.md`
+
 ## Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ ClawPack is an application-layer packaging and distribution tool for [OpenClaw](
 
 It solves a simple problem: standardized export, import, and verification of a tuned OpenClaw Agent. It's not a container or a VM — it's an application-level distribution package built on top of those infrastructures.
 
+## Product Direction
+
+The repository started with an OpenClaw-first packaging CLI, but the broader product direction is now clearer: ClawPack is evolving toward a harness image packaging standard for agent runtime environments, with OpenClaw as the first production adapter.
+
+For the current product framing, see:
+
+- `docs/prds/0002-product-foundation.md`
+- `docs/prds/0003-roadmap-mvp-to-v1.md`
+- `docs/architecture/0001-harness-image-architecture.md`
+
 ## Why
 
 An OpenClaw agent's usable state is more than just code or config. It includes:

--- a/README_zh.md
+++ b/README_zh.md
@@ -12,6 +12,16 @@ ClawPack 是一个面向 [OpenClaw](https://github.com/openclaw/openclaw) Agent 
 
 它解决的问题很简单：将一个已经调好的 OpenClaw Agent **标准化地导出、导入和验证**。它不是容器，也不是虚拟机，而是建立在这些基础设施之上的应用层分发包。
 
+## 产品方向
+
+这个仓库最初从一个 OpenClaw 优先的打包 CLI 出发，但现在更清晰的产品方向已经形成：ClawPack 正在演进为一个面向 Agent 运行环境的 harness image 打包标准，而 OpenClaw 是第一个生产级适配器。
+
+当前产品定义见：
+
+- `docs/prds/0002-product-foundation.md`
+- `docs/prds/0003-roadmap-mvp-to-v1.md`
+- `docs/architecture/0001-harness-image-architecture.md`
+
 ## 为什么需要 ClawPack
 
 一个 OpenClaw Agent 的可用状态不只是代码或配置，还包括：

--- a/docs/architecture/0001-harness-image-architecture.md
+++ b/docs/architecture/0001-harness-image-architecture.md
@@ -1,0 +1,152 @@
+# Harness Image Architecture
+
+## Status
+
+Target architecture for the product line.
+
+This document describes the 1.0-oriented architecture and the MVP subset that should be implemented first.
+
+## Architectural Decision
+
+ClawPack should adopt a 1.0-oriented harness image architecture now, then implement only the MVP subset of that architecture.
+
+This avoids a split where the MVP is a flat OpenClaw snapshot tool but 1.0 needs a different conceptual model.
+
+## 1.0 Architecture
+
+At 1.0, the architecture should be organized around six layers.
+
+### 1. Image Specification Layer
+
+Defines the portable image contract:
+
+- image identity
+- schema version
+- pack type
+- included components
+- workspace bindings
+- sensitivity and risk metadata
+- parent image references
+- layer ordering
+- import-time rebinding requirements
+- verification expectations
+
+### 2. Adapter Layer
+
+Product-specific adapters translate concrete runtimes into the image model.
+
+Examples:
+
+- OpenClaw adapter
+- future non-OpenClaw agent runtime adapters
+
+An adapter is responsible for:
+
+- inspection rules
+- source layout detection
+- component classification
+- rebinding rules
+- import materialization rules
+
+### 3. Image Builder Layer
+
+Builds a harness image from adapter output.
+
+Responsibilities:
+
+- stage files
+- separate layers and components
+- compute manifest
+- emit archive or installation material
+
+### 4. Composition Layer
+
+Resolves parent/base image references and composes layered harnesses into a final materialized environment.
+
+Responsibilities:
+
+- merge ordered layers
+- apply override rules
+- detect conflicts
+- preserve lineage metadata
+
+### 5. Import And Materialization Layer
+
+Restores a harness image into a target environment.
+
+Responsibilities:
+
+- unpack image content
+- materialize composed layers
+- perform rebinding
+- persist imported manifest metadata
+
+### 6. Verification Layer
+
+Validates the imported result against both filesystem expectations and image semantics.
+
+Responsibilities:
+
+- structural checks
+- schema checks
+- binding checks
+- layer expectation checks
+- adapter-specific validation hooks
+
+## MVP Architecture Subset
+
+The MVP should implement the same architecture in reduced form.
+
+### Present In MVP
+
+- image specification layer
+- OpenClaw adapter layer
+- image builder layer
+- import and materialization layer
+- verification layer
+
+### Deferred From MVP
+
+- full composition engine
+- parent image resolution
+- registry-backed image lookup
+- sophisticated layer conflict resolution
+
+## Mapping To The Current Repository
+
+The current repository already roughly maps to this architecture:
+
+- `src/core/types.ts`
+  image specification seed
+- `src/core/scanner.ts`
+  OpenClaw adapter seed
+- `src/core/packer.ts`
+  builder plus import and materialization seed
+- `src/core/verifier.ts`
+  verification seed
+
+What is still missing is explicit separation of concerns around:
+
+- adapter abstraction
+- image identity vs source-instance identity
+- parent and layer semantics
+- composition rules
+
+## Recommended Near-Term Refactor Direction
+
+The next architectural moves should be:
+
+1. separate OpenClaw-specific detection and materialization logic from generic image-building logic
+2. evolve `Manifest` toward a true `HarnessImageManifest`
+3. introduce explicit image references and reserved parent and layer fields without requiring full composition yet
+4. keep CLI verbs stable while improving the internal model
+
+## Why This Is Architecture-Consistent
+
+This direction keeps the public CLI simple while changing the internal center of gravity:
+
+- from filesystem snapshot operations
+- toward adapter-driven harness image construction
+
+That is an additive evolution, not a rewrite, provided the internal abstractions are introduced before too much more product surface area accumulates.
+

--- a/docs/prds/0001-prd-v0.1.md
+++ b/docs/prds/0001-prd-v0.1.md
@@ -1,5 +1,11 @@
 # ClawPack
 
+> Historical note: this document records the original OpenClaw-first `v0.1` scope.
+> For the current top-level product framing, see:
+> - `docs/prds/0002-product-foundation.md`
+> - `docs/prds/0003-roadmap-mvp-to-v1.md`
+> - `docs/architecture/0001-harness-image-architecture.md`
+
 ClawPack 是一个面向 OpenClaw 类 Agent 的应用层打包与分发工具。
 
 它解决的问题很简单：把一个已经调好的 OpenClaw Agent，标准化地导出、导入和验证。它不是容器，也不是虚拟机，而是建立在这些基础设施之上的应用层分发包。

--- a/docs/prds/0002-product-foundation.md
+++ b/docs/prds/0002-product-foundation.md
@@ -1,0 +1,129 @@
+# ClawPack Product Foundation
+
+## Status
+
+Current top-level product direction document.
+
+The earlier [0001-prd-v0.1](./0001-prd-v0.1.md) remains useful as the original OpenClaw-first starting point, but it no longer captures the full intended product scope.
+
+## Product Thesis
+
+ClawPack should be defined as a harness image packaging standard for agent runtime environments.
+
+OpenClaw is the first production-grade adapter, not the terminal scope of the product.
+
+## Problem Statement
+
+An agent that works well in practice depends on more than prompt text or source code. It usually depends on a harness:
+
+- workspace instructions
+- prompts and skills
+- provider and channel configuration
+- tools and extensions
+- runtime state and memory
+- safety and operational guardrails
+- domain-specific working context
+
+These environments are still copied ad hoc, rebuilt manually, or hidden inside one-off runtime directories. That makes them hard to reuse, audit, version, migrate, and improve systematically.
+
+## Product Goal
+
+ClawPack exists to make harness environments portable, layered, inspectable, and reusable.
+
+It should let teams define, package, distribute, compose, and validate agent harness images in the same way container tooling lets teams define and distribute runtime environments.
+
+## Core Definitions
+
+### Harness
+
+A harness is the application-layer operating environment that helps an agent work reliably.
+
+It may include:
+
+- instructions and workspace files
+- skills and reusable operational patterns
+- tool configuration
+- provider and channel settings
+- runtime state and memory
+- verification metadata
+- local development and safety guardrails
+
+### Harness Image
+
+A harness image is a portable, versioned packaging unit for a harness.
+
+It should describe:
+
+- what environment is being packaged
+- what layers or components it contains
+- what must be rebound at import time
+- what safety and risk characteristics apply
+- what base image or parent image it depends on
+
+### Layer
+
+A layer is a reusable subset of a harness image.
+
+Examples:
+
+- a base secure-development harness
+- a general marketing-agent harness
+- an ecommerce-operations harness
+- a Xiaohongshu agriculture marketing harness
+
+Layers should be composable so specialized harnesses can build on more general ones instead of copying everything into one flat package.
+
+## Ultimate Product Goal
+
+The terminal goal is not just "package OpenClaw directories".
+
+The terminal goal is:
+
+1. define a general harness image model for agent runtime environments
+2. provide one strong OpenClaw adapter as the first production-grade implementation
+3. enable layered reuse so generic harnesses and domain harnesses can be composed
+4. make harness environments importable, verifiable, and governable across teams
+
+## Core Product Axis
+
+The product should be organized around one main axis:
+
+`agent harness image lifecycle`
+
+That lifecycle is:
+
+`inspect -> define -> compose -> export -> import -> verify -> evolve`
+
+The current repository already covers only a narrower slice:
+
+`inspect -> export -> import -> verify`
+
+The missing pieces are:
+
+- explicit harness definition
+- parent/base image relationships
+- layer composition
+- versioned compatibility contracts
+- reusable image catalogs or registries
+
+## Design Principles
+
+- OpenClaw-first, not OpenClaw-only
+- image model first, transport format second
+- layered reuse over flat snapshot copying
+- explicit safety and rebinding contracts
+- architecture continuity from MVP to 1.0
+- repository harness and runtime harness should align conceptually, but they are not the same artifact
+
+## What ClawPack Is Not
+
+ClawPack is not:
+
+- a container runtime
+- a VM image builder
+- a hosted agent platform
+- a prompt library only
+- a one-off backup script
+
+It is the application-layer image system for agent harnesses.
+

--- a/docs/prds/0003-roadmap-mvp-to-v1.md
+++ b/docs/prds/0003-roadmap-mvp-to-v1.md
@@ -1,0 +1,114 @@
+# ClawPack Roadmap: MVP To 1.0
+
+## Status
+
+Current roadmap and version framing document.
+
+## Version Framing
+
+The repository's original `v0.1` should now be treated as a historical seed release:
+
+- it proves the narrow OpenClaw packaging loop can work
+- it is not yet the full product definition
+- it should inform the MVP rather than define the final product shape
+
+## MVP Goal
+
+The MVP should prove that ClawPack can package and restore a reusable harness image with a stable, extensible format.
+
+The MVP is intentionally narrow, but it must already reflect the eventual 1.0 architecture direction.
+
+## MVP Scope
+
+The MVP should deliver:
+
+1. one production-grade adapter: OpenClaw
+2. one canonical image format: `.clawpack`
+3. one minimal lifecycle slice:
+   `inspect -> export -> import -> verify`
+4. one base image model with explicit metadata for:
+   - source product
+   - included components
+   - workspace bindings
+   - rebinding requirements
+   - risk and sensitivity flags
+5. two image modes:
+   - share-oriented image
+   - migration-oriented image
+6. one local CLI implementation
+7. one repository harness good enough to keep the format and CLI evolving safely
+
+## MVP Non-goals
+
+The MVP should not require:
+
+- hosted registry
+- image marketplace
+- full visual UI
+- deep layer inheritance
+- cross-product universal adapters
+- cryptographic signing
+- advanced policy engines
+
+## MVP Success Criteria
+
+- users can reliably package and restore an OpenClaw harness image
+- the manifest model is already extensible enough for future layering
+- import-time rebinding is explicit and testable
+- verification checks the restored environment and consumed manifest coherently
+- the codebase does not assume OpenClaw is the only future adapter
+
+## 1.0 Goal
+
+Version 1.0 should establish ClawPack as the standard image system for agent harness environments, with a stable layered image model and at least one fully mature adapter.
+
+## 1.0 Scope
+
+Version 1.0 should deliver:
+
+1. a stable harness image specification
+2. layered image composition
+3. parent/base image references and inheritance metadata
+4. install/import behavior that can materialize a composed harness
+5. verification that understands image lineage and layer expectations
+6. OpenClaw as a complete first-class adapter
+7. local image catalog or registry primitives
+8. stronger safety boundaries for share-oriented vs migration-oriented images
+9. upgrade and compatibility rules for image schema evolution
+
+## 1.0 Non-goals
+
+Version 1.0 still does not need to imply:
+
+- full SaaS hosting
+- multi-tenant execution platform
+- a public marketplace as a launch requirement
+- every agent framework on day one
+
+## Relationship Between MVP And 1.0
+
+The MVP and 1.0 should be architecture-consistent.
+
+The MVP is not a throwaway OpenClaw exporter that later gets replaced. It is the first adapter and first transport implementation of the eventual harness image system.
+
+That means:
+
+- the manifest must already have room for image identity, components, bindings, and future parent references
+- the pack builder and importer must be organized around an image model rather than raw file copying alone
+- verification must already consume manifest semantics, not only filesystem structure
+- OpenClaw-specific logic should sit behind adapter-shaped boundaries
+
+## Main Product Transition
+
+The key conceptual transition is:
+
+from:
+
+- package one OpenClaw instance
+
+to:
+
+- define and transport a reusable harness image, with OpenClaw as the first adapter
+
+That transition should happen now at the documentation and architecture level, even if the implementation sequence remains incremental.
+


### PR DESCRIPTION
Closes #13

Add canonical product direction docs that define the terminal goal, core product axis, MVP boundary, 1.0 boundary, and the architecture relationship between them.

Implementation notes:
Preserve the original `v0.1` PRD as a historical seed rather than rewriting history.

Validation:
- doc review against current implementation and roadmap intent
- `./scripts/run-agent-preflight.sh`
