### PR TITLE
Update metadata after HarnessHub migration

### DIFF
--- a/.codex/pm/issue-state/15-update-harnesshub-metadata.md
+++ b/.codex/pm/issue-state/15-update-harnesshub-metadata.md
@@ -1,0 +1,34 @@
+---
+type: issue_state
+issue: 15
+task: .codex/pm/tasks/product-direction/update-harnesshub-metadata.md
+title: Update repository metadata and remotes after HarnessHub migration
+status: in_progress
+---
+
+## Summary
+
+Track the repository rename follow-up so local remotes, repository metadata, and GitHub repo descriptions all point to the new HarnessHub locations.
+
+## Validated Facts
+
+- the upstream repository now lives at `HarnessHub/HarnessHub`
+- the fork now lives at `yaoyinnan/HarnessHub`
+- tracked files still contain old `Mrxuexi/clawpack` URLs and descriptions
+
+## Open Questions
+
+- whether a future issue should rename the shipped CLI and package from `clawpack` as well
+
+## Next Steps
+
+- none; ready for review
+
+## Artifacts
+
+- issue #15
+- `package.json`
+- `README.md`
+- `README_zh.md`
+- `AGENTS.md`
+- `CONTRIBUTING.md`

--- a/.codex/pm/tasks/product-direction/update-harnesshub-metadata.md
+++ b/.codex/pm/tasks/product-direction/update-harnesshub-metadata.md
@@ -1,0 +1,43 @@
+---
+type: task
+epic: product-direction
+slug: update-harnesshub-metadata
+title: Update repository metadata and remotes after HarnessHub migration
+status: in_progress
+task_type: implementation
+labels: docs,chore
+issue: 15
+state_path: .codex/pm/issue-state/15-update-harnesshub-metadata.md
+---
+
+## Context
+
+The project has been renamed and migrated to `HarnessHub/HarnessHub`, and the fork has moved to `yaoyinnan/HarnessHub`. The local remotes and repository metadata should match that rename.
+
+
+## Deliverable
+
+Update local remotes, repository metadata, and visible repository descriptions so the repo consistently points at the HarnessHub locations.
+
+
+## Scope
+
+- repoint local `origin` and `upstream`
+- update repository metadata URLs and descriptions in tracked files
+- update local workflow defaults that still point to the old repository
+- apply the same GitHub repository description to the upstream repo and the fork
+
+## Acceptance Criteria
+
+- local git remotes point to the renamed repositories
+- tracked repository metadata no longer points to `Mrxuexi/clawpack` or `yaoyinnan/clawpack`
+- both GitHub repositories use the same updated description
+
+## Validation
+
+- `npm test`
+- `git remote -v`
+
+## Implementation Notes
+
+Keep the current CLI name `clawpack` unchanged in this issue to avoid mixing repository migration with package-level breaking changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,9 @@
 
 This file provides guidance to AI coding agents (Claude Code, Codex, Cursor, etc.) when working with code in this repository.
 
-## What is ClawPack?
+## What is HarnessHub?
 
-ClawPack is an application-layer packaging and distribution CLI for OpenClaw agents. It packages an agent's workspace, config, state, and credentials into a portable `.clawpack` archive (gzipped tar containing `manifest.json`, `config/`, `workspace/`, `state/`, `reports/`).
+HarnessHub is the project name for the repository's harness image system. The current implementation still ships as the `clawpack` CLI for OpenClaw-oriented packaging flows, using a portable `.clawpack` archive (gzipped tar containing `manifest.json`, `config/`, `workspace/`, `state/`, `reports/`).
 
 The broader product direction is documented in:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
-# Contributing to ClawPack
+# Contributing to HarnessHub
 
 Thanks for your interest in contributing! Here's how to get started.
 
 ## Development Setup
 
 ```bash
-git clone https://github.com/Mrxuexi/clawpack.git
-cd clawpack
+git clone https://github.com/HarnessHub/HarnessHub.git
+cd HarnessHub
 npm install
 npm run build
 npm test

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 <p align="center">
-  <img src="./assets/logo.png" alt="ClawPack" width="200" />
+  <img src="./assets/logo.png" alt="HarnessHub" width="200" />
 </p>
 
-<h1 align="center">ClawPack</h1>
+<h1 align="center">HarnessHub</h1>
 
 <p align="center">
   <a href="./README_zh.md">中文文档</a>
 </p>
 
-ClawPack is an application-layer packaging and distribution tool for [OpenClaw](https://github.com/openclaw/openclaw) agents.
+HarnessHub is a harness image packaging standard for agent runtime environments.
 
-It solves a simple problem: standardized export, import, and verification of a tuned OpenClaw Agent. It's not a container or a VM — it's an application-level distribution package built on top of those infrastructures.
+The current implementation ships as the `clawpack` CLI and started with standardized export, import, and verification of tuned OpenClaw agents. It's not a container or a VM; it is the application-layer packaging system built on top of those infrastructures.
 
 ## Product Direction
 
-The repository started with an OpenClaw-first packaging CLI, but the broader product direction is now clearer: ClawPack is evolving toward a harness image packaging standard for agent runtime environments, with OpenClaw as the first production adapter.
+The repository started with an OpenClaw-first packaging CLI, but the broader product direction is now clearer: HarnessHub is evolving toward a harness image packaging standard for agent runtime environments, with OpenClaw as the first production adapter.
 
 For the current product framing, see:
 
@@ -290,8 +290,8 @@ clawpack inspect -f json | jq '.riskAssessment'
 ## Development
 
 ```bash
-git clone https://github.com/Mrxuexi/clawpack.git
-cd clawpack
+git clone https://github.com/HarnessHub/HarnessHub.git
+cd HarnessHub
 npm install
 npm run build
 npm test

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,20 +1,20 @@
 <p align="center">
-  <img src="./assets/logo.png" alt="ClawPack" width="200" />
+  <img src="./assets/logo.png" alt="HarnessHub" width="200" />
 </p>
 
-<h1 align="center">ClawPack</h1>
+<h1 align="center">HarnessHub</h1>
 
 <p align="center">
   <a href="./README.md">English</a>
 </p>
 
-ClawPack 是一个面向 [OpenClaw](https://github.com/openclaw/openclaw) Agent 的应用层打包与分发工具。
+HarnessHub 是一个面向 Agent 运行环境的 harness image 打包标准。
 
-它解决的问题很简单：将一个已经调好的 OpenClaw Agent **标准化地导出、导入和验证**。它不是容器，也不是虚拟机，而是建立在这些基础设施之上的应用层分发包。
+当前实现仍通过 `clawpack` CLI 提供，并且最初从对 OpenClaw Agent 的**标准化导出、导入和验证**出发。它不是容器，也不是虚拟机，而是建立在这些基础设施之上的应用层打包系统。
 
 ## 产品方向
 
-这个仓库最初从一个 OpenClaw 优先的打包 CLI 出发，但现在更清晰的产品方向已经形成：ClawPack 正在演进为一个面向 Agent 运行环境的 harness image 打包标准，而 OpenClaw 是第一个生产级适配器。
+这个仓库最初从一个 OpenClaw 优先的打包 CLI 出发，但现在更清晰的产品方向已经形成：HarnessHub 正在演进为一个面向 Agent 运行环境的 harness image 打包标准，而 OpenClaw 是第一个生产级适配器。
 
 当前产品定义见：
 
@@ -289,8 +289,8 @@ clawpack inspect -f json | jq '.riskAssessment'
 ## 开发
 
 ```bash
-git clone https://github.com/Mrxuexi/clawpack.git
-cd clawpack
+git clone https://github.com/HarnessHub/HarnessHub.git
+cd HarnessHub
 npm install
 npm run build
 npm test

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clawpack",
   "version": "0.1.0",
-  "description": "Application-layer packaging and distribution tool for OpenClaw agents",
+  "description": "Harness image packaging standard for agent runtime environments, currently implemented through the clawpack CLI",
   "type": "module",
   "main": "dist/cli.js",
   "bin": {
@@ -35,11 +35,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Mrxuexi/clawpack.git"
+    "url": "git+https://github.com/HarnessHub/HarnessHub.git"
   },
-  "homepage": "https://github.com/Mrxuexi/clawpack#readme",
+  "homepage": "https://github.com/HarnessHub/HarnessHub#readme",
   "bugs": {
-    "url": "https://github.com/Mrxuexi/clawpack/issues"
+    "url": "https://github.com/HarnessHub/HarnessHub/issues"
   },
   "author": "Mrxuexi",
   "engines": {

--- a/scripts/codex-pm.mjs
+++ b/scripts/codex-pm.mjs
@@ -310,7 +310,7 @@ function prCreate(args, io) {
     issue,
     tests,
     title: options.title,
-    baseRepo: options["base-repo"] ?? inferBaseRepo() ?? "Mrxuexi/clawpack",
+    baseRepo: options["base-repo"] ?? inferBaseRepo() ?? "HarnessHub/HarnessHub",
     baseBranch: options["base-branch"] ?? "main",
     headOwner: options["head-owner"],
     headBranch: options["head-branch"],

--- a/test/pre-push-hook.test.ts
+++ b/test/pre-push-hook.test.ts
@@ -17,8 +17,8 @@ function prepareRepo() {
   git(repo, "init", "-b", "main");
   git(repo, "config", "user.name", "Test User");
   git(repo, "config", "user.email", "test@example.com");
-  git(repo, "remote", "add", "origin", "git@github.com:test/clawpack.git");
-  git(repo, "remote", "add", "upstream", "https://github.com/Mrxuexi/clawpack.git");
+  git(repo, "remote", "add", "origin", "git@github.com:test/HarnessHub.git");
+  git(repo, "remote", "add", "upstream", "https://github.com/HarnessHub/HarnessHub.git");
 
   const sourceRoot = "/workspace/02-projects/active/clawpack";
   fs.mkdirSync(path.join(repo, ".githooks"), { recursive: true });
@@ -144,7 +144,7 @@ describe("pre-push hook", () => {
     fs.writeFileSync(path.join(binDir, "gh"), `#!/usr/bin/env bash
 set -euo pipefail
 if [[ "$1" == "pr" && "$2" == "list" ]]; then
-  echo '[{"number":4,"url":"https://github.com/Mrxuexi/clawpack/pull/4"}]'
+  echo '[{"number":4,"url":"https://github.com/HarnessHub/HarnessHub/pull/4"}]'
   exit 0
 fi
 if [[ "$1" == "pr" && "$2" == "view" ]]; then


### PR DESCRIPTION
Closes #15

Update local remotes, repository metadata, and visible repository descriptions so the repo consistently points at the HarnessHub locations.

Implementation notes:
Keep the current CLI name `clawpack` unchanged in this issue to avoid mixing repository migration with package-level breaking changes.

Validation:
- `npm test`
- `git remote -v`
- `./scripts/run-agent-preflight.sh`
