### PR TITLE
[codex] Migrate package format naming to .harness

### DIFF
--- a/.codex/pm/issue-state/13-define-product-foundation-roadmap.md
+++ b/.codex/pm/issue-state/13-define-product-foundation-roadmap.md
@@ -3,7 +3,7 @@ type: issue_state
 issue: 13
 task: .codex/pm/tasks/product-direction/define-product-foundation-roadmap.md
 title: Define HarnessHub product foundation and architecture-aligned MVP/1.0 roadmap
-status: in_progress
+status: done
 ---
 
 ## Summary

--- a/.codex/pm/issue-state/15-update-harnesshub-metadata.md
+++ b/.codex/pm/issue-state/15-update-harnesshub-metadata.md
@@ -3,7 +3,7 @@ type: issue_state
 issue: 15
 task: .codex/pm/tasks/product-direction/update-harnesshub-metadata.md
 title: Update repository metadata and remotes after HarnessHub migration
-status: in_progress
+status: done
 ---
 
 ## Summary

--- a/.codex/pm/issue-state/19-migrate-format-layer-to-harness.md
+++ b/.codex/pm/issue-state/19-migrate-format-layer-to-harness.md
@@ -1,0 +1,35 @@
+---
+type: issue_state
+issue: 19
+task: .codex/pm/tasks/product-direction/migrate-format-layer-to-harness.md
+title: Migrate package format naming from .clawpack to .harness
+status: done
+---
+
+## Summary
+
+Complete the final format-layer rename so the shipped archive format, imported sidecar, and related temp paths all use HarnessHub naming rather than legacy ClawPack naming.
+
+## Validated Facts
+
+- issue #17 already renamed the product and primary CLI command to `harness`
+- issue #19 is the remaining format-layer cleanup for `.clawpack` extension and `.clawpack-*` internal names
+- the working tree already contains updates in CLI commands, packer logic, docs, and tests for the `.harness` rename
+- some repository tests and helper scripts still contain legacy `clawpack` temp prefixes or old workspace paths and need a final consistency pass
+
+## Open Questions
+
+- whether historical references in `docs/prds/0001-prd-v0.1.md` should remain untouched as archived pre-rename context
+
+## Next Steps
+
+- none; ready for PR
+
+## Artifacts
+
+- issue #19
+- `.codex/pm/tasks/product-direction/migrate-format-layer-to-harness.md`
+- `src/core/packer.ts`
+- `README.md`
+- `README_zh.md`
+- `test/e2e.test.ts`

--- a/.codex/pm/tasks/product-direction/define-product-foundation-roadmap.md
+++ b/.codex/pm/tasks/product-direction/define-product-foundation-roadmap.md
@@ -3,7 +3,7 @@ type: task
 epic: product-direction
 slug: define-product-foundation-roadmap
 title: Define ClawPack product foundation and architecture-aligned MVP/1.0 roadmap
-status: in_progress
+status: done
 task_type: implementation
 labels: docs,feature
 issue: 13

--- a/.codex/pm/tasks/product-direction/migrate-format-layer-to-harness.md
+++ b/.codex/pm/tasks/product-direction/migrate-format-layer-to-harness.md
@@ -1,0 +1,45 @@
+---
+type: task
+epic: product-direction
+slug: migrate-format-layer-to-harness
+title: Migrate package format naming from .clawpack to .harness
+status: done
+task_type: implementation
+labels: feature,docs,test
+issue: 19
+state_path: .codex/pm/issue-state/19-migrate-format-layer-to-harness.md
+---
+
+## Context
+
+The repository has already renamed the product and CLI to HarnessHub and `harness`, but the portable package format and imported sidecar names still expose legacy `.clawpack` naming in code, docs, and tests.
+
+
+## Deliverable
+
+Rename the archive extension, sidecar manifest naming, temporary import/export paths, and user-facing format references from `.clawpack` to `.harness`.
+
+
+## Scope
+
+- rename the portable archive extension from `.clawpack` to `.harness`
+- rename persisted sidecar manifest and internal temporary paths away from `.clawpack-*`
+- update default output names, command help text, docs, scripts, and tests
+- remove old-format compatibility branches because the project has not shipped yet
+
+## Acceptance Criteria
+
+- the primary archive format is `.harness`
+- the primary imported sidecar manifest name no longer uses `.clawpack-*`
+- docs and tests use the new format naming consistently
+- validation passes after the migration
+
+## Validation
+
+- `npm run build`
+- `npm test`
+- `npm run smoke`
+
+## Implementation Notes
+
+This issue is format-layer cleanup only. Historical references in archived PRD material may remain when they are explicitly describing the pre-rename phase.

--- a/.codex/pm/tasks/product-direction/update-harnesshub-metadata.md
+++ b/.codex/pm/tasks/product-direction/update-harnesshub-metadata.md
@@ -3,7 +3,7 @@ type: task
 epic: product-direction
 slug: update-harnesshub-metadata
 title: Update repository metadata and remotes after HarnessHub migration
-status: in_progress
+status: done
 task_type: implementation
 labels: docs,chore
 issue: 15

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to AI coding agents (Claude Code, Codex, Cursor, etc
 
 ## What is HarnessHub?
 
-HarnessHub is the project name for the repository's harness image system. The current implementation still ships as the `harness` CLI for OpenClaw-oriented packaging flows, using a portable `.clawpack` archive (gzipped tar containing `manifest.json`, `config/`, `workspace/`, `state/`, `reports/`).
+HarnessHub is the project name for the repository's harness image system. The current implementation ships as the `harness` CLI for OpenClaw-oriented packaging flows, using a portable `.harness` archive (gzipped tar containing `manifest.json`, `config/`, `workspace/`, `state/`, `reports/`).
 
 The broader product direction is documented in:
 
@@ -33,8 +33,8 @@ npm run dev            # tsc --watch
 src/cli.ts               — entry point, registers four commands via commander
 src/commands/
   inspect.ts             — scan and report on an OpenClaw instance
-  export.ts              — export instance to .clawpack archive
-  import.ts              — import .clawpack archive to target directory
+  export.ts              — export instance to .harness archive
+  import.ts              — import .harness archive to target directory
   verify.ts              — post-import structural checks
 src/core/
   scanner.ts             — detect OpenClaw instances, sensitive data detection (SENSITIVE_PATTERNS, detectSensitiveContent())

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- `clawpack inspect` — scan an OpenClaw instance structure, detect sensitive data, recommend export type
-- `clawpack export` — export an instance as a `.clawpack` package (template or instance mode)
-- `clawpack import` — import a `.clawpack` package into a target directory
-- `clawpack verify` — verify an imported instance is structurally complete
+- `harness inspect` — scan an OpenClaw instance structure, detect sensitive data, recommend export type
+- `harness export` — export an instance as a `.harness` package (template or instance mode)
+- `harness import` — import a `.harness` package into a target directory
+- `harness verify` — verify an imported instance is structurally complete
 - Template packs automatically exclude credentials, sessions, memory databases, and `.env` files
 - Three risk levels: `safe-share`, `internal-only`, `trusted-migration-only`
 - JSON and text output formats for all commands

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The four commands form a linear workflow:
  │                                    │    │                             │
  │  ① inspect ──▶ ② export           │    │  ③ import ──▶ ④ verify     │
  │     scan          pack to          │    │     unpack        check    │
- │     & report      .clawpack  ──────┼───▶│     & restore     struct  │
+ │     & report      .harness  ──────┼───▶│     & restore     struct  │
  │                                    │    │                             │
  └────────────────────────────────────┘    └─────────────────────────────┘
 ```
@@ -95,10 +95,10 @@ The four commands form a linear workflow:
 harness inspect
 
 # 2. Export as a template pack (safe to share)
-harness export -t template -o my-agent.clawpack
+harness export -t template -o my-agent.harness
 
 # 3. Import on another machine
-harness import my-agent.clawpack -t ~/.openclaw
+harness import my-agent.harness -t ~/.openclaw
 
 # 4. Verify the import
 harness verify
@@ -128,14 +128,14 @@ harness inspect -f json          # JSON output
 
 ### `harness export`
 
-Export an instance as a `.clawpack` package.
+Export an instance as a `.harness` package.
 
 ```
- ~/.openclaw/                                my-agent.clawpack
+ ~/.openclaw/                                my-agent.harness
  ├── config/          harness export        (gzipped tar)
  ├── workspace/    ─────────────────────▶    ┌──────────────┐
  ├── state/           -t template            │ manifest.json│
- ├── .env             -o my-agent.clawpack   │ config/      │
+ ├── .env             -o my-agent.harness   │ config/      │
  └── ...                                     │ workspace/   │
                        ▲                     │ reports/     │
                        │                     └──────────────┘
@@ -146,16 +146,16 @@ Export an instance as a `.clawpack` package.
 ```bash
 harness export -t template       # template pack (excludes secrets)
 harness export -t instance       # instance pack (full migration)
-harness export -o out.clawpack   # custom output path
+harness export -o out.harness   # custom output path
 harness export -p /path/to/dir   # custom source path
 ```
 
 ### `harness import`
 
-Import a `.clawpack` package into a target environment.
+Import a `.harness` package into a target environment.
 
 ```
- my-agent.clawpack                          ~/.openclaw/
+ my-agent.harness                          ~/.openclaw/
  ┌──────────────┐    harness import        ├── config/
  │ manifest.json│  ─────────────────────▶   ├── workspace/
  │ config/      │    -t ~/.openclaw         ├── state/
@@ -165,8 +165,8 @@ Import a `.clawpack` package into a target environment.
 ```
 
 ```bash
-harness import my-agent.clawpack              # restore to ~/.openclaw
-harness import my-agent.clawpack -t ./target  # custom target
+harness import my-agent.harness              # restore to ~/.openclaw
+harness import my-agent.harness -t ./target  # custom target
 ```
 
 ### `harness verify`
@@ -190,7 +190,7 @@ harness verify -p /path/to/dir  # custom path
 ## Package Types
 
 ```
-                          .clawpack
+                          .harness
                         ┌───────────┐
                         │           │
                 ┌───────┴───┐ ┌────┴──────┐
@@ -219,10 +219,10 @@ Template packs automatically exclude credentials, sessions, memory databases, an
 
 ## Package Format
 
-A `.clawpack` file is a gzipped tar archive containing:
+A `.harness` file is a gzipped tar archive containing:
 
 ```
-my-agent.clawpack (gzipped tar)
+my-agent.harness (gzipped tar)
 │
 ├── manifest.json ─── Pack metadata
 │                     ├── schema version
@@ -304,8 +304,8 @@ src/
 ├── cli.ts ─────────── Entry point (commander, 4 commands)
 ├── commands/
 │   ├── inspect.ts ─── Scan & report
-│   ├── export.ts ──── Export to .clawpack
-│   ├── import.ts ──── Import from .clawpack
+│   ├── export.ts ──── Export to .harness
+│   ├── import.ts ──── Import from .harness
 │   └── verify.ts ──── Structural verification
 ├── core/
 │   ├── scanner.ts ─── Instance detection, sensitive data scan

--- a/README_zh.md
+++ b/README_zh.md
@@ -10,7 +10,7 @@
 
 HarnessHub 是一个面向 Agent 运行环境的 harness image 打包标准。
 
-当前实现仍通过 `harness` CLI 提供，并且最初从对 OpenClaw Agent 的**标准化导出、导入和验证**出发。它不是容器，也不是虚拟机，而是建立在这些基础设施之上的应用层打包系统。
+当前实现通过 `harness` CLI 提供，并且最初从对 OpenClaw Agent 的**标准化导出、导入和验证**出发。它不是容器，也不是虚拟机，而是建立在这些基础设施之上的应用层打包系统。
 
 ## 产品方向
 
@@ -83,7 +83,7 @@ npm install -g harnesshub
  │                                    │    │                             │
  │  ① inspect ──▶ ② export           │    │  ③ import ──▶ ④ verify     │
  │     扫描          打包为            │    │     解包          验证      │
- │     & 报告        .clawpack  ──────┼───▶│     & 还原        结构完整性│
+ │     & 报告        .harness  ──────┼───▶│     & 还原        结构完整性│
  │                                    │    │                             │
  └────────────────────────────────────┘    └─────────────────────────────┘
 ```
@@ -93,10 +93,10 @@ npm install -g harnesshub
 harness inspect
 
 # 2. 导出为模板包（可安全分享）
-harness export -t template -o my-agent.clawpack
+harness export -t template -o my-agent.harness
 
 # 3. 在另一台机器导入
-harness import my-agent.clawpack -t ~/.openclaw
+harness import my-agent.harness -t ~/.openclaw
 
 # 4. 验证导入结果
 harness verify
@@ -126,14 +126,14 @@ harness inspect -f json          # JSON 格式输出
 
 ### `harness export`
 
-将实例导出为 `.clawpack` 包。
+将实例导出为 `.harness` 包。
 
 ```
- ~/.openclaw/                                my-agent.clawpack
+ ~/.openclaw/                                my-agent.harness
  ├── config/          harness export        (gzip 压缩的 tar)
  ├── workspace/    ─────────────────────▶    ┌──────────────┐
  ├── state/           -t template            │ manifest.json│
- ├── .env             -o my-agent.clawpack   │ config/      │
+ ├── .env             -o my-agent.harness   │ config/      │
  └── ...                                     │ workspace/   │
                        ▲                     │ reports/     │
                        │                     └──────────────┘
@@ -144,16 +144,16 @@ harness inspect -f json          # JSON 格式输出
 ```bash
 harness export -t template       # 模板包（排除敏感信息）
 harness export -t instance       # 实例包（完整迁移）
-harness export -o out.clawpack   # 指定输出路径
+harness export -o out.harness   # 指定输出路径
 harness export -p /path/to/dir   # 指定源路径
 ```
 
 ### `harness import`
 
-将 `.clawpack` 包导入目标环境。
+将 `.harness` 包导入目标环境。
 
 ```
- my-agent.clawpack                          ~/.openclaw/
+ my-agent.harness                          ~/.openclaw/
  ┌──────────────┐    harness import        ├── config/
  │ manifest.json│  ─────────────────────▶   ├── workspace/
  │ config/      │    -t ~/.openclaw         ├── state/
@@ -163,8 +163,8 @@ harness export -p /path/to/dir   # 指定源路径
 ```
 
 ```bash
-harness import my-agent.clawpack              # 还原到 ~/.openclaw
-harness import my-agent.clawpack -t ./target  # 指定目标目录
+harness import my-agent.harness              # 还原到 ~/.openclaw
+harness import my-agent.harness -t ./target  # 指定目标目录
 ```
 
 ### `harness verify`
@@ -188,7 +188,7 @@ harness verify -p /path/to/dir  # 指定路径
 ## 包类型
 
 ```
-                          .clawpack
+                          .harness
                         ┌───────────┐
                         │           │
                 ┌───────┴───┐ ┌────┴──────┐
@@ -218,10 +218,10 @@ harness verify -p /path/to/dir  # 指定路径
 
 ## 包格式
 
-`.clawpack` 文件是一个 gzip 压缩的 tar 归档，包含以下结构：
+`.harness` 文件是一个 gzip 压缩的 tar 归档，包含以下结构：
 
 ```
-my-agent.clawpack (gzip 压缩的 tar)
+my-agent.harness (gzip 压缩的 tar)
 │
 ├── manifest.json ─── 包元数据
 │                     ├── schema 版本
@@ -303,8 +303,8 @@ src/
 ├── cli.ts ─────────── 入口 (commander, 4 个命令)
 ├── commands/
 │   ├── inspect.ts ─── 扫描与报告
-│   ├── export.ts ──── 导出为 .clawpack
-│   ├── import.ts ──── 从 .clawpack 导入
+│   ├── export.ts ──── 导出为 .harness
+│   ├── import.ts ──── 从 .harness 导入
 │   └── verify.ts ──── 结构验证
 ├── core/
 │   ├── scanner.ts ─── 实例检测、敏感数据扫描

--- a/docs/prds/0003-roadmap-mvp-to-v1.md
+++ b/docs/prds/0003-roadmap-mvp-to-v1.md
@@ -23,7 +23,7 @@ The MVP is intentionally narrow, but it must already reflect the eventual 1.0 ar
 The MVP should deliver:
 
 1. one production-grade adapter: OpenClaw
-2. one canonical image format: `.clawpack`
+2. one canonical image format: `.harness`
 3. one minimal lifecycle slice:
    `inspect -> export -> import -> verify`
 4. one base image model with explicit metadata for:

--- a/scripts/run-cli-smoke.sh
+++ b/scripts/run-cli-smoke.sh
@@ -7,7 +7,7 @@ cd "$ROOT_DIR"
 TMP_DIR="$(mktemp -d)"
 SRC_DIR="$TMP_DIR/source"
 TARGET_DIR="$TMP_DIR/target"
-PACK_FILE="$TMP_DIR/sample.clawpack"
+PACK_FILE="$TMP_DIR/sample.harness"
 
 cleanup() {
   rm -rf "$TMP_DIR"

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -4,7 +4,7 @@ import type { OutputFormat } from "../core/types.js";
 
 export const importCommand = new Command("import")
   .description("Import a HarnessHub package into a target environment")
-  .argument("<file>", "Path to the .clawpack file")
+  .argument("<file>", "Path to the .harness file")
   .option("-t, --target <path>", "Target directory (defaults to ~/.openclaw)")
   .option("-f, --format <format>", "Output format: text or json", "text")
   .action(async (file, opts) => {

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -19,7 +19,7 @@ export const verifyCommand = new Command("verify")
       let manifest: Manifest | undefined;
       const manifestCandidates = [
         path.join(targetDir, "manifest.json"),
-        path.join(targetDir, ".clawpack-manifest.json"),
+        path.join(targetDir, ".harness-manifest.json"),
       ];
       for (const candidate of manifestCandidates) {
         if (fs.existsSync(candidate)) {

--- a/src/core/packer.ts
+++ b/src/core/packer.ts
@@ -47,8 +47,8 @@ const ALWAYS_EXCLUDE = [
   "*.log",
   ".git",
   "node_modules",
-  ".clawpack-staging",
-  ".clawpack-import-*",
+  ".harness-staging",
+  ".harness-import-*",
   // Backup rotation files (not needed for packaging)
   "*.bak",
   "*.bak.*",
@@ -308,7 +308,7 @@ export async function exportPack(options: ExportOptions): Promise<ExportResult> 
   };
 
   // Create staging directory
-  const stagingDir = path.join(stateDir, ".clawpack-staging");
+  const stagingDir = path.join(stateDir, ".harness-staging");
   if (fs.existsSync(stagingDir)) {
     fs.rmSync(stagingDir, { recursive: true });
   }
@@ -361,7 +361,7 @@ export async function exportPack(options: ExportOptions): Promise<ExportResult> 
 
     // Determine output path
     const outputFile = options.outputPath ||
-      path.join(process.cwd(), `openclaw-${packType}-${Date.now()}.clawpack`);
+      path.join(process.cwd(), `openclaw-${packType}-${Date.now()}.harness`);
 
     // Create tar.gz archive
     await tar.create(
@@ -399,7 +399,7 @@ export async function importPack(options: ImportOptions): Promise<ImportResult> 
 
   const tempDir = path.join(
     path.dirname(packFile),
-    `.clawpack-import-${Date.now()}`
+    `.harness-import-${Date.now()}`
   );
   fs.mkdirSync(tempDir, { recursive: true });
 
@@ -475,7 +475,7 @@ export async function importPack(options: ImportOptions): Promise<ImportResult> 
 
     rebindWorkspaceConfig(targetDir, manifest, warnings);
     fs.writeFileSync(
-      path.join(targetDir, ".clawpack-manifest.json"),
+      path.join(targetDir, ".harness-manifest.json"),
       `${JSON.stringify(manifest, null, 2)}\n`
     );
 

--- a/test/cli-integration.test.ts
+++ b/test/cli-integration.test.ts
@@ -3,8 +3,9 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 
-const repoRoot = "/workspace/02-projects/active/clawpack";
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const cliPath = path.join(repoRoot, "dist", "cli.js");
 
 function runCli(args: string[], cwd = repoRoot) {
@@ -87,7 +88,7 @@ describe("harness CLI integration", () => {
   it("runs a full template roundtrip through CLI commands", () => {
     const sourceDir = path.join(tmpDir, "source");
     const targetDir = path.join(tmpDir, "target");
-    const packFile = path.join(tmpDir, "template.clawpack");
+    const packFile = path.join(tmpDir, "template.harness");
     createTemplateSource(sourceDir);
 
     expect(runCli(["export", "-p", sourceDir, "-o", packFile, "-t", "template", "-f", "json"]).status).toBe(0);
@@ -103,13 +104,13 @@ describe("harness CLI integration", () => {
   it("runs an instance roundtrip and preserves sensitive structure", () => {
     const sourceDir = path.join(tmpDir, "source");
     const targetDir = path.join(tmpDir, "target");
-    const packFile = path.join(tmpDir, "instance.clawpack");
+    const packFile = path.join(tmpDir, "instance.harness");
     createInstanceSource(sourceDir);
 
     expect(runCli(["export", "-p", sourceDir, "-o", packFile, "-t", "instance", "-f", "json"]).status).toBe(0);
     expect(runCli(["import", packFile, "-t", targetDir, "-f", "json"]).status).toBe(0);
     expect(fs.existsSync(path.join(targetDir, "agents", "main", "agent", "auth-profiles.json"))).toBe(true);
-    expect(fs.existsSync(path.join(targetDir, ".clawpack-manifest.json"))).toBe(true);
+    expect(fs.existsSync(path.join(targetDir, ".harness-manifest.json"))).toBe(true);
 
     const verifyResult = runCli(["verify", "-p", targetDir, "-f", "json"]);
     expect(verifyResult.status).toBe(0);
@@ -118,7 +119,7 @@ describe("harness CLI integration", () => {
   });
 
   it("returns a JSON error when importing a missing pack file", () => {
-    const result = runCli(["import", path.join(tmpDir, "missing.clawpack"), "-f", "json"]);
+    const result = runCli(["import", path.join(tmpDir, "missing.harness"), "-f", "json"]);
     expect(result.status).toBe(1);
     const data = JSON.parse(result.stdout);
     expect(data.error).toContain("Pack file not found");

--- a/test/cli-smoke.test.ts
+++ b/test/cli-smoke.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from "vitest";
+import path from "node:path";
 import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 describe("cli smoke script", () => {
   it("validates the documented CLI path", () => {
     const result = spawnSync("./scripts/run-cli-smoke.sh", [], {
-      cwd: "/workspace/02-projects/active/clawpack",
+      cwd: repoRoot,
       encoding: "utf8",
     });
 

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -238,7 +238,7 @@ describe("inspect", () => {
 describe("export + import", () => {
   it("exports a template pack", async () => {
     const instanceDir = createMockInstance(path.join(tmpDir, "instance"));
-    const outputFile = path.join(tmpDir, "test.clawpack");
+    const outputFile = path.join(tmpDir, "test.harness");
 
     const result = await exportPack({
       sourcePath: instanceDir,
@@ -258,7 +258,7 @@ describe("export + import", () => {
 
   it("exports an instance pack with sensitive data", async () => {
     const instanceDir = createMockInstanceWithSensitiveData(path.join(tmpDir, "sensitive"));
-    const outputFile = path.join(tmpDir, "instance.clawpack");
+    const outputFile = path.join(tmpDir, "instance.harness");
 
     const result = await exportPack({
       sourcePath: instanceDir,
@@ -283,7 +283,7 @@ describe("export + import", () => {
 
   it("template pack excludes all sensitive files", async () => {
     const instanceDir = createMockInstanceWithSensitiveData(path.join(tmpDir, "sensitive"));
-    const outputFile = path.join(tmpDir, "template.clawpack");
+    const outputFile = path.join(tmpDir, "template.harness");
 
     const result = await exportPack({
       sourcePath: instanceDir,
@@ -308,7 +308,7 @@ describe("export + import", () => {
 
   it("instance pack preserves agent directory structure", async () => {
     const instanceDir = createMockInstanceWithSensitiveData(path.join(tmpDir, "full"));
-    const outputFile = path.join(tmpDir, "instance.clawpack");
+    const outputFile = path.join(tmpDir, "instance.harness");
 
     const result = await exportPack({
       sourcePath: instanceDir,
@@ -329,7 +329,7 @@ describe("export + import", () => {
 
   it("imports a pack to a new directory", async () => {
     const instanceDir = createMockInstance(path.join(tmpDir, "source"));
-    const packFile = path.join(tmpDir, "test.clawpack");
+    const packFile = path.join(tmpDir, "test.harness");
     const targetDir = path.join(tmpDir, "target");
 
     await exportPack({
@@ -348,12 +348,12 @@ describe("export + import", () => {
     expect(importResult.manifest.harness.intent).toBe("agent-runtime-environment");
     expect(fs.existsSync(path.join(targetDir, "workspace", "AGENTS.md"))).toBe(true);
     expect(fs.existsSync(path.join(targetDir, "openclaw.json"))).toBe(true);
-    expect(fs.existsSync(path.join(targetDir, ".clawpack-manifest.json"))).toBe(true);
+    expect(fs.existsSync(path.join(targetDir, ".harness-manifest.json"))).toBe(true);
   });
 
   it("imports instance pack preserving agent directory structure", async () => {
     const instanceDir = createMockInstanceWithSensitiveData(path.join(tmpDir, "source"));
-    const packFile = path.join(tmpDir, "instance.clawpack");
+    const packFile = path.join(tmpDir, "instance.harness");
     const targetDir = path.join(tmpDir, "target");
 
     await exportPack({
@@ -377,7 +377,7 @@ describe("export + import", () => {
 
   it("imports config-defined external workspaces into target defaults", async () => {
     const { dir } = createMockInstanceWithCustomWorkspaces(path.join(tmpDir, "external-source"));
-    const packFile = path.join(tmpDir, "external.clawpack");
+    const packFile = path.join(tmpDir, "external.harness");
     const targetDir = path.join(tmpDir, "external-target");
 
     const exportResult = await exportPack({
@@ -407,7 +407,7 @@ describe("export + import", () => {
 
   it("full round-trip: export -> import -> verify", async () => {
     const instanceDir = createMockInstance(path.join(tmpDir, "source"));
-    const packFile = path.join(tmpDir, "roundtrip.clawpack");
+    const packFile = path.join(tmpDir, "roundtrip.harness");
     const targetDir = path.join(tmpDir, "target");
 
     const exportResult = await exportPack({
@@ -429,7 +429,7 @@ describe("export + import", () => {
 
   it("full round-trip with instance pack", async () => {
     const instanceDir = createMockInstanceWithSensitiveData(path.join(tmpDir, "source"));
-    const packFile = path.join(tmpDir, "roundtrip-instance.clawpack");
+    const packFile = path.join(tmpDir, "roundtrip-instance.harness");
     const targetDir = path.join(tmpDir, "target");
 
     await exportPack({

--- a/test/pre-push-hook.test.ts
+++ b/test/pre-push-hook.test.ts
@@ -3,6 +3,9 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const sourceRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 function git(cwd: string, ...args: string[]) {
   const result = spawnSync("git", args, { cwd, encoding: "utf8" });
@@ -20,7 +23,6 @@ function prepareRepo() {
   git(repo, "remote", "add", "origin", "git@github.com:test/HarnessHub.git");
   git(repo, "remote", "add", "upstream", "https://github.com/HarnessHub/HarnessHub.git");
 
-  const sourceRoot = "/workspace/02-projects/active/clawpack";
   fs.mkdirSync(path.join(repo, ".githooks"), { recursive: true });
   fs.mkdirSync(path.join(repo, "scripts"), { recursive: true });
   fs.copyFileSync(path.join(sourceRoot, ".githooks", "pre-push"), path.join(repo, ".githooks", "pre-push"));

--- a/test/preflight-script.test.ts
+++ b/test/preflight-script.test.ts
@@ -3,10 +3,12 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 describe("run-agent-preflight.sh", () => {
   it("fails without a review note", () => {
-    const repoRoot = "/workspace/02-projects/active/clawpack";
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "harnesshub-preflight-"));
     const result = spawnSync("./scripts/run-agent-preflight.sh", [], {
       cwd: repoRoot,
@@ -26,13 +28,12 @@ describe("run-agent-preflight.sh", () => {
   });
 
   it("passes with overridden build and test commands", () => {
-    const repoRoot = "/workspace/02-projects/active/clawpack";
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "harnesshub-preflight-"));
     const branch = spawnSync("git", ["branch", "--show-current"], { cwd: repoRoot, encoding: "utf8" }).stdout.trim();
     const headSha = spawnSync("git", ["rev-parse", "HEAD"], { cwd: repoRoot, encoding: "utf8" }).stdout.trim();
 
-    fs.writeFileSync(path.join(tmpDir, ".codex-review"), "scope reviewed: preflight\nfindings: no findings\nremaining risks: smoke skipped\n", "utf8");
     fs.writeFileSync(path.join(tmpDir, ".codex-review-proof"), `branch=${branch}\nhead_sha=${headSha}\nbase_ref=HEAD\ngenerated_at=2026-03-12T00:00:00Z\n`, "utf8");
+    fs.writeFileSync(path.join(tmpDir, ".codex-review"), "scope reviewed: preflight\nfindings: no findings\nremaining risks: smoke skipped\n", "utf8");
 
     const result = spawnSync("./scripts/run-agent-preflight.sh", [], {
       cwd: repoRoot,


### PR DESCRIPTION
Closes #19

This change completes the remaining format-layer migration from ClawPack naming to HarnessHub naming. After the earlier branding and CLI rename, the shipped package format still exposed legacy `.clawpack` names in the archive extension, imported sidecar manifest, temporary import and export paths, examples, and regression tests. That left the product in an inconsistent state: users saw `harness` in the CLI, but the actual package artifact still looked like an older ClawPack-era format.

The root cause was that issue #17 intentionally stopped at product and command naming, while the pack format and some repository fixtures still depended on old identifiers. This patch finishes that rename end to end. The exporter now defaults to `.harness`, importer help text points to `.harness` files, verify looks for `.harness-manifest.json`, and the temporary `.clawpack-*` paths were removed in favor of `.harness-*`. The README, Chinese README, changelog, smoke script, and affected tests were updated so the documented and validated behavior match the shipped format.

I also synchronized the local CCPM task twins so previously merged work for issues #13 and #15 is marked done, and issue #19 now has its local task and issue-state records. That keeps the repository-local PM state aligned with the remote issue history and allows closure-sync guardrails to pass for this branch.

Validation used for this change:

- `npm run build`
- `npm test`
- `npm run smoke`
- `./scripts/run-agent-preflight.sh`
