### PR TITLE
[codex] Codify harness vs runtime boundary

### DIFF
--- a/.codex/pm/issue-state/23-codify-harness-vs-agent-runtime-boundary.md
+++ b/.codex/pm/issue-state/23-codify-harness-vs-agent-runtime-boundary.md
@@ -1,0 +1,31 @@
+---
+type: issue_state
+issue: 23
+task: .codex/pm/tasks/product-direction/codify-harness-vs-agent-runtime-boundary.md
+title: Codify harness vs agent runtime boundary in core docs
+status: done
+---
+
+## Summary
+
+Codify the conceptual boundary between harness and agent runtime in the canonical product and architecture docs so implementation work stays focused on the harness layer.
+
+## Validated Facts
+
+- HarnessHub is intended to package the application-layer harness rather than replace the runtime execution substrate
+- future implementation issues depend on a stable wording for this distinction
+- the needed doc changes live in `docs/prds/0002-product-foundation.md` and `docs/architecture/0001-harness-image-architecture.md`
+
+## Open Questions
+
+- none
+
+## Next Steps
+
+- none; ready for PR
+
+## Artifacts
+
+- issue #23
+- `docs/prds/0002-product-foundation.md`
+- `docs/architecture/0001-harness-image-architecture.md`

--- a/.codex/pm/tasks/product-direction/codify-harness-vs-agent-runtime-boundary.md
+++ b/.codex/pm/tasks/product-direction/codify-harness-vs-agent-runtime-boundary.md
@@ -1,0 +1,40 @@
+---
+type: task
+epic: product-direction
+slug: codify-harness-vs-agent-runtime-boundary
+title: Codify harness vs agent runtime boundary in core docs
+status: done
+task_type: implementation
+labels: docs,architecture
+issue: 23
+state_path: .codex/pm/issue-state/23-codify-harness-vs-agent-runtime-boundary.md
+---
+
+## Context
+
+The product and architecture direction now rely on a clear distinction between the harness layer and the agent runtime layer, but that boundary was not yet captured explicitly in the canonical docs.
+
+## Deliverable
+
+Add explicit harness-versus-runtime definitions and boundary language to the core product foundation and architecture documents.
+
+## Scope
+
+- define `Agent Runtime` alongside `Harness` in the product foundation
+- explain the practical runtime vs harness distinction in product-facing language
+- add an architecture-level boundary clarification that keeps HarnessHub out of runtime-platform scope
+
+## Acceptance Criteria
+
+- the product foundation explicitly distinguishes harness from agent runtime
+- the architecture doc explicitly states that HarnessHub packages the harness layer rather than replacing the runtime
+- the wording is precise enough to guide future implementation issue decomposition
+
+## Validation
+
+- doc review against the MVP and 1.0 framing
+- doc review against the architecture boundary needed for adapter work
+
+## Implementation Notes
+
+Keep this issue limited to codifying conceptual boundaries. Do not expand into runtime feature work or implementation refactors here.

--- a/docs/architecture/0001-harness-image-architecture.md
+++ b/docs/architecture/0001-harness-image-architecture.md
@@ -12,6 +12,16 @@ HarnessHub should adopt a 1.0-oriented harness image architecture now, then impl
 
 This avoids a split where the MVP is a flat OpenClaw snapshot tool but 1.0 needs a different conceptual model.
 
+## Boundary Clarification
+
+HarnessHub is not the agent runtime itself.
+
+The runtime layer is responsible for execution concerns such as process startup, model calls, tool invocation machinery, persistence services, and host integration.
+
+The harness layer is responsible for the reusable application-layer operating environment around the agent, including instructions, skills, configuration, bindings, guardrails, and selected state that must travel with the working environment.
+
+This distinction matters because HarnessHub should package, compose, import, and verify the harness layer while remaining compatible with existing runtimes rather than trying to replace them.
+
 ## 1.0 Architecture
 
 At 1.0, the architecture should be organized around six layers.
@@ -47,6 +57,8 @@ An adapter is responsible for:
 - component classification
 - rebinding rules
 - import materialization rules
+
+An adapter does not redefine the runtime's execution engine. It maps a runtime's concrete layout into HarnessHub's harness-image model.
 
 ### 3. Image Builder Layer
 
@@ -148,5 +160,9 @@ This direction keeps the public CLI simple while changing the internal center of
 - from filesystem snapshot operations
 - toward adapter-driven harness image construction
 
-That is an additive evolution, not a rewrite, provided the internal abstractions are introduced before too much more product surface area accumulates.
+It also keeps the product boundary stable:
 
+- runtimes remain the execution substrate
+- HarnessHub remains the application-layer harness packaging system
+
+That is an additive evolution, not a rewrite, provided the internal abstractions are introduced before too much more product surface area accumulates.

--- a/docs/prds/0002-product-foundation.md
+++ b/docs/prds/0002-product-foundation.md
@@ -48,6 +48,29 @@ It may include:
 - verification metadata
 - local development and safety guardrails
 
+### Agent Runtime
+
+An agent runtime is the execution environment that lets an agent process actually run.
+
+It is concerned with:
+
+- process startup and execution
+- model invocation plumbing
+- tool execution mechanisms
+- persistence and state services
+- runtime dependencies and resources
+- event loops, schedulers, and host integration
+
+The runtime answers:
+
+- how the agent runs
+
+The harness answers:
+
+- what working environment and operating method the agent runs with
+
+HarnessHub is concerned with the harness layer, not with replacing the runtime itself.
+
 ### Harness Image
 
 A harness image is a portable, versioned packaging unit for a harness.
@@ -113,6 +136,7 @@ The missing pieces are:
 - layered reuse over flat snapshot copying
 - explicit safety and rebinding contracts
 - architecture continuity from MVP to 1.0
+- harness layer distinct from runtime layer
 - repository harness and runtime harness should align conceptually, but they are not the same artifact
 
 ## What HarnessHub Is Not
@@ -127,3 +151,8 @@ HarnessHub is not:
 
 It is the application-layer image system for agent harnesses.
 
+In practical terms:
+
+- the runtime provides the execution substrate
+- the harness provides the reusable application-layer operating environment
+- HarnessHub packages and verifies the harness, not the underlying runtime platform


### PR DESCRIPTION
Closes #23

This PR codifies the boundary between the harness layer and the agent runtime layer in the canonical product and architecture documents. The distinction had already become important in product discussions, but it was still too easy for implementation work to drift conceptually toward runtime-platform scope because the docs did not state the boundary explicitly enough.

The product foundation now defines `Agent Runtime` alongside `Harness`, explains that the runtime answers how an agent runs while the harness answers what working environment and operating method it runs with, and states clearly that HarnessHub packages the harness layer rather than replacing the runtime itself. The architecture document now mirrors that distinction and clarifies that adapters map concrete runtime layouts into the HarnessHub image model instead of redefining execution engines.

This is a documentation-only change, but it is intentionally foundational. It gives the upcoming adapter, manifest, and binding issues a stable boundary so those implementation tasks can evolve the harness image system without sliding into runtime-platform scope.

Validation used for this change:

- doc review against the MVP and 1.0 framing
- doc review against the architecture boundary needed for adapter work
- `./scripts/run-agent-preflight.sh`
