### PR TITLE
[codex] Introduce explicit OpenClaw adapter boundary

### DIFF
--- a/.codex/pm/issue-state/25-introduce-explicit-openclaw-adapter-boundary.md
+++ b/.codex/pm/issue-state/25-introduce-explicit-openclaw-adapter-boundary.md
@@ -1,0 +1,33 @@
+---
+type: issue_state
+issue: 25
+task: .codex/pm/tasks/product-direction/introduce-explicit-openclaw-adapter-boundary.md
+title: Introduce explicit OpenClaw adapter boundary
+status: done
+---
+
+## Summary
+
+Introduce an explicit OpenClaw adapter object so runtime-specific inspection and rebinding behavior has a clear boundary inside the HarnessHub architecture.
+
+## Validated Facts
+
+- the MVP already behaves as an OpenClaw-first adapter even though the boundary was implicit
+- `packer.ts`, `verifier.ts`, and command handlers were directly coupled to OpenClaw-specific scanner helpers
+- a small adapter interface is sufficient to clarify the boundary without changing CLI behavior
+
+## Open Questions
+
+- none
+
+## Next Steps
+
+- none; ready for PR
+
+## Artifacts
+
+- issue #25
+- `src/core/adapters/types.ts`
+- `src/core/adapters/openclaw.ts`
+- `src/core/packer.ts`
+- `src/core/verifier.ts`

--- a/.codex/pm/tasks/product-direction/introduce-explicit-openclaw-adapter-boundary.md
+++ b/.codex/pm/tasks/product-direction/introduce-explicit-openclaw-adapter-boundary.md
@@ -1,0 +1,40 @@
+---
+type: task
+epic: product-direction
+slug: introduce-explicit-openclaw-adapter-boundary
+title: Introduce explicit OpenClaw adapter boundary
+status: done
+task_type: implementation
+labels: architecture,feature
+issue: 25
+state_path: .codex/pm/issue-state/25-introduce-explicit-openclaw-adapter-boundary.md
+---
+
+## Context
+
+The current MVP implementation already behaves like an OpenClaw-first adapter, but the runtime-specific responsibilities for state resolution, config discovery, workspace binding, inspection, and import-time rebinding are still coupled directly into generic pack and verify flows.
+
+## Deliverable
+
+Introduce an explicit OpenClaw adapter boundary so generic harness image flows depend on adapter methods rather than on scattered OpenClaw-specific helper calls.
+
+## Scope
+
+- introduce a small adapter interface for harness runtime adapters
+- add an explicit `openClawAdapter` implementation for current OpenClaw-specific responsibilities
+- route inspect, export, import, and verify flows through the adapter boundary without changing CLI behavior
+
+## Acceptance Criteria
+
+- OpenClaw-specific state/config/workspace and rebinding logic is reachable through an explicit adapter object
+- generic pack and verify code no longer import those responsibilities directly from scanner helpers
+- current build and tests remain green after the refactor
+
+## Validation
+
+- `npm run build`
+- `npm test`
+
+## Implementation Notes
+
+This issue is about boundary clarity, not about introducing a second adapter yet.

--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { inspect } from "../core/scanner.js";
+import { openClawAdapter } from "../core/adapters/openclaw.js";
 import { printInspectResult } from "../utils/output.js";
 import type { OutputFormat } from "../core/types.js";
 
@@ -10,7 +10,7 @@ export const inspectCommand = new Command("inspect")
   .action((opts) => {
     const format = opts.format as OutputFormat;
     try {
-      const result = inspect(opts.path);
+      const result = openClawAdapter.inspect(opts.path);
       printInspectResult(result as unknown as Record<string, unknown>, format);
       if (!result.detected) {
         process.exitCode = 1;

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import fs from "node:fs";
 import { verify } from "../core/verifier.js";
 import { printVerifyResult } from "../utils/output.js";
-import { resolveStateDir } from "../core/scanner.js";
+import { openClawAdapter } from "../core/adapters/openclaw.js";
 import type { Manifest, OutputFormat } from "../core/types.js";
 
 export const verifyCommand = new Command("verify")
@@ -12,7 +12,7 @@ export const verifyCommand = new Command("verify")
   .option("-f, --format <format>", "Output format: text or json", "text")
   .action((opts) => {
     const format = opts.format as OutputFormat;
-    const targetDir = opts.path ? path.resolve(opts.path) : resolveStateDir();
+    const targetDir = opts.path ? path.resolve(opts.path) : openClawAdapter.resolveStateDir();
 
     try {
       // Try to find a manifest from a recent import

--- a/src/core/adapters/openclaw.ts
+++ b/src/core/adapters/openclaw.ts
@@ -1,0 +1,73 @@
+import fs from "node:fs";
+import JSON5 from "json5";
+import type { Manifest } from "../types.js";
+import {
+  findConfigFile,
+  inspect,
+  resolveStateDir,
+  resolveWorkspaceBindings,
+} from "../scanner.js";
+import type { HarnessAdapter } from "./types.js";
+
+function rebindImportedConfig(targetDir: string, manifest: Manifest, warnings: string[]) {
+  const configPath = findConfigFile(targetDir);
+  if (!configPath || manifest.workspaces.length === 0) return;
+
+  let parsed: any;
+  try {
+    parsed = JSON5.parse(fs.readFileSync(configPath, "utf-8"));
+  } catch {
+    warnings.push(`Could not parse config for workspace rebinding: ${configPath.split("/").pop()}`);
+    return;
+  }
+
+  if (!parsed || typeof parsed !== "object") return;
+
+  if (!parsed.agents || typeof parsed.agents !== "object") {
+    parsed.agents = {};
+  }
+  if (!parsed.agents.defaults || typeof parsed.agents.defaults !== "object") {
+    parsed.agents.defaults = {};
+  }
+  if (!Array.isArray(parsed.agents.list)) {
+    parsed.agents.list = [];
+  }
+
+  let changed = false;
+
+  for (const workspace of manifest.workspaces) {
+    const targetWorkspacePath = workspace.isDefault
+      ? `${targetDir}/workspace`
+      : `${targetDir}/${workspace.logicalPath}`;
+
+    if (workspace.isDefault && parsed.agents.defaults.workspace !== targetWorkspacePath) {
+      parsed.agents.defaults.workspace = targetWorkspacePath;
+      changed = true;
+    }
+
+    const agentEntry = parsed.agents.list.find((entry: any) => {
+      const id = typeof entry?.id === "string" ? entry.id.trim().toLowerCase() : "";
+      return id === workspace.agentId;
+    });
+    if (agentEntry && agentEntry.workspace !== targetWorkspacePath) {
+      agentEntry.workspace = targetWorkspacePath;
+      changed = true;
+    }
+  }
+
+  if (!changed) return;
+
+  fs.writeFileSync(configPath, `${JSON.stringify(parsed, null, 2)}\n`);
+  warnings.push(
+    `Rebound workspace paths in ${configPath.split("/").pop()} to ${targetDir}; JSON5 formatting/comments were normalized.`
+  );
+}
+
+export const openClawAdapter: HarnessAdapter = {
+  id: "openclaw",
+  resolveStateDir,
+  findConfigFile,
+  resolveWorkspaceBindings,
+  inspect,
+  rebindImportedConfig,
+};

--- a/src/core/adapters/types.ts
+++ b/src/core/adapters/types.ts
@@ -1,0 +1,11 @@
+import type { InspectResult, Manifest } from "../types.js";
+import type { ResolvedWorkspaceBinding } from "../scanner.js";
+
+export interface HarnessAdapter {
+  readonly id: string;
+  resolveStateDir(customPath?: string): string;
+  findConfigFile(stateDir: string): string | null;
+  resolveWorkspaceBindings(stateDir: string, configPath: string | null): ResolvedWorkspaceBinding[];
+  inspect(customPath?: string): InspectResult;
+  rebindImportedConfig(targetDir: string, manifest: Manifest, warnings: string[]): void;
+}

--- a/src/core/packer.ts
+++ b/src/core/packer.ts
@@ -13,7 +13,7 @@ import type {
   WorkspaceBinding,
 } from "./types.js";
 import { SCHEMA_VERSION } from "./types.js";
-import { inspect, resolveStateDir, findConfigFile, resolveWorkspaceBindings } from "./scanner.js";
+import { openClawAdapter } from "./adapters/openclaw.js";
 
 // Files/dirs to exclude from template packs (security-critical)
 const TEMPLATE_EXCLUDES = [
@@ -237,19 +237,19 @@ interface ExportResult {
 }
 
 export async function exportPack(options: ExportOptions): Promise<ExportResult> {
-  const stateDir = resolveStateDir(options.sourcePath);
-  const configPath = findConfigFile(stateDir);
+  const stateDir = openClawAdapter.resolveStateDir(options.sourcePath);
+  const configPath = openClawAdapter.findConfigFile(stateDir);
   if (!fs.existsSync(stateDir)) {
     throw new Error(`OpenClaw state directory not found: ${stateDir}`);
   }
 
-  const inspectResult = inspect(options.sourcePath);
+  const inspectResult = openClawAdapter.inspect(options.sourcePath);
   if (!inspectResult.detected) {
     throw new Error("No OpenClaw instance detected at the specified path");
   }
 
   const packType = options.packType;
-  const resolvedWorkspaceBindings = resolveWorkspaceBindings(stateDir, configPath);
+  const resolvedWorkspaceBindings = openClawAdapter.resolveWorkspaceBindings(stateDir, configPath);
   const workspaceBindings = resolvedWorkspaceBindings.map<WorkspaceBinding>((binding) => ({
     agentId: binding.agentId,
     logicalPath: binding.logicalPath,
@@ -425,7 +425,7 @@ export async function importPack(options: ImportOptions): Promise<ImportResult> 
 
     const targetDir = options.targetPath
       ? path.resolve(options.targetPath)
-      : resolveStateDir();
+      : openClawAdapter.resolveStateDir();
 
     const warnings: string[] = [];
 
@@ -473,7 +473,7 @@ export async function importPack(options: ImportOptions): Promise<ImportResult> 
       restoreStateDir(stateSource, targetDir);
     }
 
-    rebindWorkspaceConfig(targetDir, manifest, warnings);
+    openClawAdapter.rebindImportedConfig(targetDir, manifest, warnings);
     fs.writeFileSync(
       path.join(targetDir, ".harness-manifest.json"),
       `${JSON.stringify(manifest, null, 2)}\n`
@@ -538,60 +538,6 @@ function restoreStateDir(stateSource: string, targetDir: string) {
       fs.copyFileSync(src, dest);
     }
   }
-}
-
-function rebindWorkspaceConfig(targetDir: string, manifest: Manifest, warnings: string[]) {
-  const configPath = findConfigFile(targetDir);
-  if (!configPath || manifest.workspaces.length === 0) return;
-
-  let parsed: any;
-  try {
-    parsed = JSON5.parse(fs.readFileSync(configPath, "utf-8"));
-  } catch {
-    warnings.push(`Could not parse config for workspace rebinding: ${path.basename(configPath)}`);
-    return;
-  }
-
-  if (!parsed || typeof parsed !== "object") return;
-
-  if (!parsed.agents || typeof parsed.agents !== "object") {
-    parsed.agents = {};
-  }
-  if (!parsed.agents.defaults || typeof parsed.agents.defaults !== "object") {
-    parsed.agents.defaults = {};
-  }
-  if (!Array.isArray(parsed.agents.list)) {
-    parsed.agents.list = [];
-  }
-
-  let changed = false;
-
-  for (const workspace of manifest.workspaces) {
-    const targetWorkspacePath = workspace.isDefault
-      ? path.join(targetDir, "workspace")
-      : path.join(targetDir, workspace.logicalPath);
-
-    if (workspace.isDefault && parsed.agents.defaults.workspace !== targetWorkspacePath) {
-      parsed.agents.defaults.workspace = targetWorkspacePath;
-      changed = true;
-    }
-
-    const agentEntry = parsed.agents.list.find((entry: any) => {
-      const id = typeof entry?.id === "string" ? entry.id.trim().toLowerCase() : "";
-      return id === workspace.agentId;
-    });
-    if (agentEntry && agentEntry.workspace !== targetWorkspacePath) {
-      agentEntry.workspace = targetWorkspacePath;
-      changed = true;
-    }
-  }
-
-  if (!changed) return;
-
-  fs.writeFileSync(configPath, `${JSON.stringify(parsed, null, 2)}\n`);
-  warnings.push(
-    `Rebound workspace paths in ${path.basename(configPath)} to ${targetDir}; JSON5 formatting/comments were normalized.`
-  );
 }
 
 function copyDirRecursive(src: string, dest: string) {

--- a/src/core/verifier.ts
+++ b/src/core/verifier.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import JSON5 from "json5";
 import type { Manifest, VerifyResult, VerifyCheck } from "./types.js";
 import { SCHEMA_VERSION } from "./types.js";
-import { findConfigFile, resolveWorkspaceBindings } from "./scanner.js";
+import { openClawAdapter } from "./adapters/openclaw.js";
 
 const REQUIRED_WORKSPACE_FILES = ["AGENTS.md"];
 
@@ -29,7 +29,7 @@ export function verify(targetDir: string, manifest?: Manifest): VerifyResult {
   }
 
   // Check 2: Config file exists
-  const configPath = findConfigFile(targetDir);
+  const configPath = openClawAdapter.findConfigFile(targetDir);
   const hasConfig = configPath !== null;
   checks.push({
     name: "config_exists",
@@ -43,7 +43,7 @@ export function verify(targetDir: string, manifest?: Manifest): VerifyResult {
   }
 
   // Check 3: Workspace directory exists
-  const resolvedWorkspaces = resolveWorkspaceBindings(targetDir, configPath);
+  const resolvedWorkspaces = openClawAdapter.resolveWorkspaceBindings(targetDir, configPath);
   const workspaceDirs = manifestWorkspaces.length > 0
     ? manifestWorkspaces.map((workspace) =>
         workspace.isDefault ? "workspace" : workspace.logicalPath


### PR DESCRIPTION
Closes #25

This PR introduces an explicit OpenClaw adapter boundary inside the current MVP architecture. The existing implementation already behaved as an OpenClaw-first adapter, but the boundary was implicit: generic pack and verify flows imported OpenClaw-specific helpers for state directory resolution, config discovery, workspace binding, inspection, and import-time rebinding directly from scanner logic.

The change adds a small adapter interface and an `openClawAdapter` implementation that owns those runtime-specific responsibilities. The main export, import, inspect, and verify flows now depend on the adapter instead of reaching into OpenClaw-specific helpers directly. This keeps the public CLI and current behavior stable while making the internal architecture much more explicit about where a concrete runtime adapter attaches.

The result is not a full multi-adapter system yet, and it intentionally does not try to generalize everything at once. It simply establishes the first clear seam so the later manifest and binding issues can continue moving the codebase toward the documented adapter-shaped architecture without rewriting the CLI surface.

Validation used for this change:

- `npm run build`
- `npm test`
- `./scripts/run-agent-preflight.sh`
