### PR TITLE
[codex] Evolve manifest into explicit image contract

### DIFF
--- a/.codex/pm/issue-state/24-evolve-manifest-into-explicit-harness-image-contract.md
+++ b/.codex/pm/issue-state/24-evolve-manifest-into-explicit-harness-image-contract.md
@@ -1,0 +1,33 @@
+---
+type: issue_state
+issue: 24
+task: .codex/pm/tasks/product-direction/evolve-manifest-into-explicit-harness-image-contract.md
+title: Evolve manifest into explicit Harness image contract
+status: done
+---
+
+## Summary
+
+Evolve the manifest from a simple export record into a clearer harness image contract with explicit image identity and reserved lineage metadata.
+
+## Validated Facts
+
+- the manifest already drives import and verify behavior in the MVP
+- image identity was still implicit in `packId` rather than modeled explicitly
+- parent and layer lineage needed reserved schema space before later composition work
+
+## Open Questions
+
+- none
+
+## Next Steps
+
+- none; ready for PR
+
+## Artifacts
+
+- issue #24
+- `src/core/types.ts`
+- `src/core/packer.ts`
+- `src/core/verifier.ts`
+- `test/e2e.test.ts`

--- a/.codex/pm/tasks/product-direction/evolve-manifest-into-explicit-harness-image-contract.md
+++ b/.codex/pm/tasks/product-direction/evolve-manifest-into-explicit-harness-image-contract.md
@@ -1,0 +1,40 @@
+---
+type: task
+epic: product-direction
+slug: evolve-manifest-into-explicit-harness-image-contract
+title: Evolve manifest into explicit Harness image contract
+status: done
+task_type: implementation
+labels: architecture,feature
+issue: 24
+state_path: .codex/pm/issue-state/24-evolve-manifest-into-explicit-harness-image-contract.md
+---
+
+## Context
+
+The current manifest already carries enough data for the MVP lifecycle, but it still reads mostly like an export record. The contract needs explicit image identity and reserved lineage structure so future layering work has a stable place to grow.
+
+## Deliverable
+
+Extend the manifest into a clearer harness image contract with explicit image metadata and reserved lineage fields while preserving current import/export behavior.
+
+## Scope
+
+- add explicit image identity metadata distinct from source runtime metadata
+- reserve manifest structure for future parent and layer lineage
+- update import fallback and verification so the new contract is recognized without breaking older packs
+
+## Acceptance Criteria
+
+- the manifest includes explicit image identity metadata
+- the manifest includes reserved lineage fields for future parent/layer work
+- import and verify continue to work with current packs and legacy manifests
+
+## Validation
+
+- `npm run build`
+- `npm test`
+
+## Implementation Notes
+
+Keep the current CLI surface stable. This issue evolves the contract shape without introducing composition behavior yet.

--- a/src/core/packer.ts
+++ b/src/core/packer.ts
@@ -6,6 +6,8 @@ import JSON5 from "json5";
 import type {
   HarnessComponent,
   HarnessMetadata,
+  HarnessImageLineage,
+  HarnessImageMetadata,
   Manifest,
   PackType,
   RiskLevel,
@@ -56,6 +58,20 @@ const ALWAYS_EXCLUDE = [
 
 function generatePackId(): string {
   return crypto.randomUUID();
+}
+
+function createImageMetadata(packId: string, adapter: string): HarnessImageMetadata {
+  return {
+    imageId: packId,
+    adapter,
+  };
+}
+
+function createInitialLineage(): HarnessImageLineage {
+  return {
+    parentImage: null,
+    layerOrder: [],
+  };
 }
 
 function assessRisk(sensitive: SensitiveFlags, packType: PackType): RiskLevel {
@@ -290,11 +306,14 @@ export async function exportPack(options: ExportOptions): Promise<ExportResult> 
     throw new Error("No files to export");
   }
 
+  const packId = generatePackId();
   const manifest: Manifest = {
     schemaVersion: SCHEMA_VERSION,
     packType,
-    packId: generatePackId(),
+    packId,
     createdAt: new Date().toISOString(),
+    image: createImageMetadata(packId, openClawAdapter.id),
+    lineage: createInitialLineage(),
     harness: createHarnessMetadata(includedPaths, configPath, inspectResult.product),
     source: {
       product: "openclaw",
@@ -412,8 +431,15 @@ export async function importPack(options: ImportOptions): Promise<ImportResult> 
     }
 
     const parsedManifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as Partial<Manifest>;
+    const packId = parsedManifest.packId ?? generatePackId();
     const manifest: Manifest = {
       ...parsedManifest,
+      packId,
+      image: parsedManifest.image ?? createImageMetadata(packId, parsedManifest.source?.product ?? openClawAdapter.id),
+      lineage: {
+        parentImage: parsedManifest.lineage?.parentImage ?? null,
+        layerOrder: Array.isArray(parsedManifest.lineage?.layerOrder) ? parsedManifest.lineage.layerOrder : [],
+      },
       harness: parsedManifest.harness ?? createHarnessMetadata(
         Array.isArray(parsedManifest.includedPaths) ? parsedManifest.includedPaths : [],
         parsedManifest.source?.configPath ? parsedManifest.source.configPath : null,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,4 +1,4 @@
-export const SCHEMA_VERSION = "0.4.0";
+export const SCHEMA_VERSION = "0.5.0";
 
 export type PackType = "template" | "instance";
 
@@ -11,6 +11,8 @@ export interface Manifest {
   packType: PackType;
   packId: string;
   createdAt: string;
+  image: HarnessImageMetadata;
+  lineage: HarnessImageLineage;
   harness: HarnessMetadata;
   source: {
     product: string;
@@ -24,6 +26,20 @@ export interface Manifest {
 }
 
 export type HarnessIntent = "agent-runtime-environment";
+
+export interface HarnessImageMetadata {
+  imageId: string;
+  adapter: string;
+}
+
+export interface HarnessImageReference {
+  imageId: string;
+}
+
+export interface HarnessImageLineage {
+  parentImage: HarnessImageReference | null;
+  layerOrder: string[];
+}
 
 export type HarnessComponent =
   | "workspace"

--- a/src/core/verifier.ts
+++ b/src/core/verifier.ts
@@ -148,6 +148,39 @@ export function verify(targetDir: string, manifest?: Manifest): VerifyResult {
       message: `Pack type: ${manifest.packType}`,
     });
 
+    const hasImageMetadata =
+      typeof manifest.image?.imageId === "string" &&
+      manifest.image.imageId.length > 0 &&
+      typeof manifest.image?.adapter === "string" &&
+      manifest.image.adapter.length > 0;
+    checks.push({
+      name: "manifest_image",
+      passed: hasImageMetadata,
+      message: hasImageMetadata
+        ? `Image identity: ${manifest.image.imageId} via ${manifest.image.adapter}`
+        : "Manifest image metadata missing or invalid",
+    });
+    if (!hasImageMetadata) {
+      warnings.push("Pack manifest does not declare explicit image identity metadata");
+    }
+
+    const hasLineageMetadata =
+      manifest.lineage !== undefined &&
+      Array.isArray(manifest.lineage.layerOrder) &&
+      (manifest.lineage.parentImage === null ||
+        (typeof manifest.lineage.parentImage?.imageId === "string" &&
+          manifest.lineage.parentImage.imageId.length > 0));
+    checks.push({
+      name: "manifest_lineage",
+      passed: hasLineageMetadata,
+      message: hasLineageMetadata
+        ? `Manifest lineage declared with ${manifest.lineage.layerOrder.length} reserved layers`
+        : "Manifest lineage metadata missing or invalid",
+    });
+    if (!hasLineageMetadata) {
+      warnings.push("Pack manifest does not reserve explicit lineage metadata for future composition");
+    }
+
     const hasHarnessMetadata =
       manifest.harness?.intent === "agent-runtime-environment" &&
       typeof manifest.harness?.targetProduct === "string" &&

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -249,6 +249,10 @@ describe("export + import", () => {
     expect(result.outputFile).toBe(outputFile);
     expect(result.manifest.packType).toBe("template");
     expect(result.manifest.riskLevel).toBe("safe-share");
+    expect(result.manifest.image.imageId).toBe(result.manifest.packId);
+    expect(result.manifest.image.adapter).toBe("openclaw");
+    expect(result.manifest.lineage.parentImage).toBeNull();
+    expect(result.manifest.lineage.layerOrder).toEqual([]);
     expect(result.manifest.harness.intent).toBe("agent-runtime-environment");
     expect(result.manifest.harness.targetProduct).toBe("openclaw");
     expect(result.manifest.harness.components).toEqual(["workspace", "config", "skills"]);
@@ -268,6 +272,8 @@ describe("export + import", () => {
 
     expect(result.manifest.packType).toBe("instance");
     expect(result.manifest.riskLevel).toBe("trusted-migration-only");
+    expect(result.manifest.image.imageId).toBe(result.manifest.packId);
+    expect(result.manifest.image.adapter).toBe("openclaw");
     expect(result.manifest.harness.components).toEqual([
       "workspace",
       "config",
@@ -345,6 +351,8 @@ describe("export + import", () => {
 
     expect(importResult.targetDir).toBe(targetDir);
     expect(importResult.manifest.packType).toBe("template");
+    expect(importResult.manifest.image.imageId).toBe(importResult.manifest.packId);
+    expect(importResult.manifest.lineage.layerOrder).toEqual([]);
     expect(importResult.manifest.harness.intent).toBe("agent-runtime-environment");
     expect(fs.existsSync(path.join(targetDir, "workspace", "AGENTS.md"))).toBe(true);
     expect(fs.existsSync(path.join(targetDir, "openclaw.json"))).toBe(true);
@@ -424,6 +432,8 @@ describe("export + import", () => {
     const verifyResult = verify(targetDir, importResult.manifest);
     expect(verifyResult.valid).toBe(true);
     expect(verifyResult.errors).toHaveLength(0);
+    expect(verifyResult.checks.some(c => c.name === "manifest_image" && c.passed)).toBe(true);
+    expect(verifyResult.checks.some(c => c.name === "manifest_lineage" && c.passed)).toBe(true);
     expect(verifyResult.checks.some(c => c.name === "manifest_harness" && c.passed)).toBe(true);
   });
 
@@ -446,6 +456,7 @@ describe("export + import", () => {
     const verifyResult = verify(targetDir, importResult.manifest);
     expect(verifyResult.valid).toBe(true);
     expect(verifyResult.errors).toHaveLength(0);
+    expect(verifyResult.checks.some(c => c.name === "manifest_image" && c.passed)).toBe(true);
   });
 });
 
@@ -510,6 +521,8 @@ describe("verify", () => {
       riskLevel: "safe-share",
     } as any);
 
+    expect(result.checks.some(c => c.name === "manifest_image" && !c.passed)).toBe(true);
+    expect(result.checks.some(c => c.name === "manifest_lineage" && !c.passed)).toBe(true);
     expect(result.checks.some(c => c.name === "manifest_harness" && !c.passed)).toBe(true);
     expect(result.warnings.some(w => w.includes("reusable agent runtime environment"))).toBe(true);
   });


### PR DESCRIPTION
Closes #24

This PR evolves the current manifest from a simple export record into a clearer harness image contract. The MVP already depended on manifest semantics, but image identity was still mostly implicit in `packId`, and there was no explicit reserved structure for future parent and layer lineage. That meant the manifest did not yet read like the beginning of a stable image model.

The change adds explicit `image` metadata and reserved `lineage` fields while preserving current import, export, and verify behavior. New packs now declare image identity directly, and imports of older manifests receive sensible fallback values so existing behavior does not break. Verification now understands and checks the new image and lineage metadata as part of the contract.

This does not implement composition yet. It simply gives the MVP manifest a stronger architectural center of gravity so later binding and lineage work has a stable schema location to attach to.

Validation used for this change:

- `npm run build`
- `npm test`
- `./scripts/run-agent-preflight.sh`
