### PR TITLE
[codex] Make import and verify consume binding semantics

### DIFF
--- a/.codex/pm/issue-state/26-make-import-and-verify-consume-explicit-binding-semantics.md
+++ b/.codex/pm/issue-state/26-make-import-and-verify-consume-explicit-binding-semantics.md
@@ -1,0 +1,34 @@
+---
+type: issue_state
+issue: 26
+task: .codex/pm/tasks/product-direction/make-import-and-verify-consume-explicit-binding-semantics.md
+title: Make import and verify consume explicit binding semantics
+status: done
+---
+
+## Summary
+
+Make workspace rebinding an explicit manifest contract and have both import and verify consume that contract directly.
+
+## Validated Facts
+
+- import already rebinds workspace config during restore
+- the rebinding contract needed to move out of implicit helper behavior into manifest semantics
+- verify needed a binding-aware check so rebinding correctness is validated coherently
+
+## Open Questions
+
+- none
+
+## Next Steps
+
+- none; ready for PR
+
+## Artifacts
+
+- issue #26
+- `src/core/types.ts`
+- `src/core/packer.ts`
+- `src/core/adapters/openclaw.ts`
+- `src/core/verifier.ts`
+- `test/e2e.test.ts`

--- a/.codex/pm/tasks/product-direction/make-import-and-verify-consume-explicit-binding-semantics.md
+++ b/.codex/pm/tasks/product-direction/make-import-and-verify-consume-explicit-binding-semantics.md
@@ -1,0 +1,40 @@
+---
+type: task
+epic: product-direction
+slug: make-import-and-verify-consume-explicit-binding-semantics
+title: Make import and verify consume explicit binding semantics
+status: done
+task_type: implementation
+labels: architecture,feature,test
+issue: 26
+state_path: .codex/pm/issue-state/26-make-import-and-verify-consume-explicit-binding-semantics.md
+---
+
+## Context
+
+The MVP already performs import-time workspace rebinding, but the rebinding contract was still implicit in code paths and inferred mostly from filesystem behavior plus `workspaces` metadata.
+
+## Deliverable
+
+Represent binding semantics explicitly in the manifest and make import plus verify consume that contract directly.
+
+## Scope
+
+- add explicit binding semantics to the manifest
+- drive import-time workspace rebinding from those manifest semantics
+- validate binding expectations during verify rather than relying only on filesystem structure
+
+## Acceptance Criteria
+
+- the manifest declares explicit binding semantics for imported workspaces
+- import consumes those semantics when rebinding config
+- verify checks that the imported result satisfies binding expectations
+
+## Validation
+
+- `npm run build`
+- `npm test`
+
+## Implementation Notes
+
+Keep the scope on binding semantics only. Do not introduce full parent/layer composition here.

--- a/src/core/adapters/openclaw.ts
+++ b/src/core/adapters/openclaw.ts
@@ -11,7 +11,8 @@ import type { HarnessAdapter } from "./types.js";
 
 function rebindImportedConfig(targetDir: string, manifest: Manifest, warnings: string[]) {
   const configPath = findConfigFile(targetDir);
-  if (!configPath || manifest.workspaces.length === 0) return;
+  const workspaceBindings = manifest.bindings?.workspaces ?? [];
+  if (!configPath || workspaceBindings.length === 0) return;
 
   let parsed: any;
   try {
@@ -35,12 +36,11 @@ function rebindImportedConfig(targetDir: string, manifest: Manifest, warnings: s
 
   let changed = false;
 
-  for (const workspace of manifest.workspaces) {
-    const targetWorkspacePath = workspace.isDefault
-      ? `${targetDir}/workspace`
-      : `${targetDir}/${workspace.logicalPath}`;
+  for (const workspace of workspaceBindings) {
+    const targetWorkspacePath = `${targetDir}/${workspace.targetRelativePath}`;
+    const isDefault = workspace.targetRelativePath === "workspace";
 
-    if (workspace.isDefault && parsed.agents.defaults.workspace !== targetWorkspacePath) {
+    if (isDefault && parsed.agents.defaults.workspace !== targetWorkspacePath) {
       parsed.agents.defaults.workspace = targetWorkspacePath;
       changed = true;
     }

--- a/src/core/packer.ts
+++ b/src/core/packer.ts
@@ -4,6 +4,7 @@ import crypto from "node:crypto";
 import * as tar from "tar";
 import JSON5 from "json5";
 import type {
+  BindingSemantics,
   HarnessComponent,
   HarnessMetadata,
   HarnessImageLineage,
@@ -13,6 +14,7 @@ import type {
   RiskLevel,
   SensitiveFlags,
   WorkspaceBinding,
+  WorkspaceBindingRule,
 } from "./types.js";
 import { SCHEMA_VERSION } from "./types.js";
 import { openClawAdapter } from "./adapters/openclaw.js";
@@ -71,6 +73,22 @@ function createInitialLineage(): HarnessImageLineage {
   return {
     parentImage: null,
     layerOrder: [],
+  };
+}
+
+function createBindingSemantics(workspaces: readonly WorkspaceBinding[]): BindingSemantics {
+  const workspaceRules: WorkspaceBindingRule[] = workspaces.map((workspace) => ({
+    agentId: workspace.agentId,
+    logicalPath: workspace.logicalPath,
+    targetRelativePath: workspace.isDefault ? "workspace" : workspace.logicalPath,
+    configTargets: workspace.isDefault
+      ? ["agents.defaults.workspace", `agents.list[${workspace.agentId}].workspace`]
+      : [`agents.list[${workspace.agentId}].workspace`],
+    required: true,
+  }));
+
+  return {
+    workspaces: workspaceRules,
   };
 }
 
@@ -314,6 +332,7 @@ export async function exportPack(options: ExportOptions): Promise<ExportResult> 
     createdAt: new Date().toISOString(),
     image: createImageMetadata(packId, openClawAdapter.id),
     lineage: createInitialLineage(),
+    bindings: createBindingSemantics(workspaceBindings),
     harness: createHarnessMetadata(includedPaths, configPath, inspectResult.product),
     source: {
       product: "openclaw",
@@ -439,6 +458,11 @@ export async function importPack(options: ImportOptions): Promise<ImportResult> 
       lineage: {
         parentImage: parsedManifest.lineage?.parentImage ?? null,
         layerOrder: Array.isArray(parsedManifest.lineage?.layerOrder) ? parsedManifest.lineage.layerOrder : [],
+      },
+      bindings: {
+        workspaces: Array.isArray(parsedManifest.bindings?.workspaces)
+          ? parsedManifest.bindings.workspaces
+          : createBindingSemantics(Array.isArray(parsedManifest.workspaces) ? parsedManifest.workspaces : []).workspaces,
       },
       harness: parsedManifest.harness ?? createHarnessMetadata(
         Array.isArray(parsedManifest.includedPaths) ? parsedManifest.includedPaths : [],

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -13,6 +13,7 @@ export interface Manifest {
   createdAt: string;
   image: HarnessImageMetadata;
   lineage: HarnessImageLineage;
+  bindings: BindingSemantics;
   harness: HarnessMetadata;
   source: {
     product: string;
@@ -39,6 +40,18 @@ export interface HarnessImageReference {
 export interface HarnessImageLineage {
   parentImage: HarnessImageReference | null;
   layerOrder: string[];
+}
+
+export interface BindingSemantics {
+  workspaces: WorkspaceBindingRule[];
+}
+
+export interface WorkspaceBindingRule {
+  agentId: string;
+  logicalPath: string;
+  targetRelativePath: string;
+  configTargets: string[];
+  required: boolean;
 }
 
 export type HarnessComponent =

--- a/src/core/verifier.ts
+++ b/src/core/verifier.ts
@@ -12,6 +12,7 @@ export function verify(targetDir: string, manifest?: Manifest): VerifyResult {
   const warnings: string[] = [];
   const errors: string[] = [];
   const manifestWorkspaces = manifest?.workspaces ?? [];
+  const manifestBindingRules = manifest?.bindings?.workspaces ?? [];
 
   // Check 1: Target directory exists
   const dirExists = fs.existsSync(targetDir);
@@ -211,6 +212,52 @@ export function verify(targetDir: string, manifest?: Manifest): VerifyResult {
       if (missingWorkspace) {
         warnings.push(`Missing imported workspace: ${missingWorkspace.logicalPath}`);
       }
+    }
+
+    if (manifestBindingRules.length > 0) {
+      const configPathForBindings = openClawAdapter.findConfigFile(targetDir);
+      const bindingFailures: string[] = [];
+      let parsedConfig: any = null;
+      if (configPathForBindings) {
+        try {
+          parsedConfig = JSON5.parse(fs.readFileSync(configPathForBindings, "utf-8"));
+        } catch {
+          warnings.push(`Could not parse config to validate binding semantics: ${path.basename(configPathForBindings)}`);
+        }
+      }
+
+      for (const binding of manifestBindingRules) {
+        const expectedPath = path.join(targetDir, binding.targetRelativePath);
+        if (binding.required && !fs.existsSync(expectedPath)) {
+          bindingFailures.push(`Missing bound workspace target ${binding.targetRelativePath}`);
+        }
+        if (!parsedConfig) continue;
+
+        if (binding.targetRelativePath === "workspace") {
+          if (parsedConfig.agents?.defaults?.workspace !== expectedPath) {
+            bindingFailures.push(`Default workspace binding not rebound to ${binding.targetRelativePath}`);
+          }
+        }
+
+        const agentEntry = Array.isArray(parsedConfig.agents?.list)
+          ? parsedConfig.agents.list.find((entry: any) => {
+              const id = typeof entry?.id === "string" ? entry.id.trim().toLowerCase() : "";
+              return id === binding.agentId;
+            })
+          : null;
+        if (agentEntry && agentEntry.workspace !== expectedPath) {
+          bindingFailures.push(`Agent ${binding.agentId} workspace binding not rebound to ${binding.targetRelativePath}`);
+        }
+      }
+
+      checks.push({
+        name: "binding_semantics",
+        passed: bindingFailures.length === 0,
+        message: bindingFailures.length === 0
+          ? `Binding semantics validated for ${manifestBindingRules.length} workspaces`
+          : bindingFailures.join("; "),
+      });
+      warnings.push(...bindingFailures);
     }
 
     // Check that expected file count roughly matches

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -253,6 +253,15 @@ describe("export + import", () => {
     expect(result.manifest.image.adapter).toBe("openclaw");
     expect(result.manifest.lineage.parentImage).toBeNull();
     expect(result.manifest.lineage.layerOrder).toEqual([]);
+    expect(result.manifest.bindings.workspaces).toEqual([
+      {
+        agentId: "main",
+        logicalPath: "workspace",
+        targetRelativePath: "workspace",
+        configTargets: ["agents.defaults.workspace", "agents.list[main].workspace"],
+        required: true,
+      },
+    ]);
     expect(result.manifest.harness.intent).toBe("agent-runtime-environment");
     expect(result.manifest.harness.targetProduct).toBe("openclaw");
     expect(result.manifest.harness.components).toEqual(["workspace", "config", "skills"]);
@@ -353,6 +362,7 @@ describe("export + import", () => {
     expect(importResult.manifest.packType).toBe("template");
     expect(importResult.manifest.image.imageId).toBe(importResult.manifest.packId);
     expect(importResult.manifest.lineage.layerOrder).toEqual([]);
+    expect(importResult.manifest.bindings.workspaces[0].targetRelativePath).toBe("workspace");
     expect(importResult.manifest.harness.intent).toBe("agent-runtime-environment");
     expect(fs.existsSync(path.join(targetDir, "workspace", "AGENTS.md"))).toBe(true);
     expect(fs.existsSync(path.join(targetDir, "openclaw.json"))).toBe(true);
@@ -410,6 +420,10 @@ describe("export + import", () => {
     const importedConfig = JSON.parse(fs.readFileSync(path.join(targetDir, "openclaw.json"), "utf-8"));
     expect(importedConfig.agents.defaults.workspace).toBe(path.join(targetDir, "workspace"));
     expect(importedConfig.agents.list[1].workspace).toBe(path.join(targetDir, "workspace-work"));
+    expect(importResult.manifest.bindings.workspaces.map((binding) => binding.targetRelativePath)).toEqual([
+      "workspace",
+      "workspace-work",
+    ]);
     expect(importResult.warnings.some((warning) => warning.includes("Rebound workspace paths"))).toBe(true);
   });
 
@@ -434,6 +448,7 @@ describe("export + import", () => {
     expect(verifyResult.errors).toHaveLength(0);
     expect(verifyResult.checks.some(c => c.name === "manifest_image" && c.passed)).toBe(true);
     expect(verifyResult.checks.some(c => c.name === "manifest_lineage" && c.passed)).toBe(true);
+    expect(verifyResult.checks.some(c => c.name === "binding_semantics" && c.passed)).toBe(true);
     expect(verifyResult.checks.some(c => c.name === "manifest_harness" && c.passed)).toBe(true);
   });
 
@@ -457,6 +472,7 @@ describe("export + import", () => {
     expect(verifyResult.valid).toBe(true);
     expect(verifyResult.errors).toHaveLength(0);
     expect(verifyResult.checks.some(c => c.name === "manifest_image" && c.passed)).toBe(true);
+    expect(verifyResult.checks.some(c => c.name === "binding_semantics" && c.passed)).toBe(true);
   });
 });
 


### PR DESCRIPTION
Closes #26

This PR makes workspace rebinding an explicit part of the manifest contract and has both import and verify consume that contract directly. The MVP already performed rebinding, but the behavior still lived mostly in helper logic and inferred expectations, which made it harder to reason about as an image contract.

The manifest now declares binding semantics for workspaces, including target relative paths and config rebinding targets. Import uses those semantics when rebinding imported configuration, and verify now includes a binding-aware validation pass rather than relying only on filesystem structure and indirect assumptions. Older manifests still receive fallback binding semantics derived from the existing workspace metadata so the current pack lifecycle stays compatible.

This closes the loop for the current MVP workspace model: image identity is explicit, binding expectations are explicit, and verification checks the imported environment against those declared semantics.

Validation used for this change:

- `npm run build`
- `npm test`
- `./scripts/run-agent-preflight.sh`
