### PR TITLE
[codex] Add issue-scoped execution skill

### DIFF
--- a/.codex/pm/issue-state/33-add-repo-local-skill-for-issue-scoped-execution-workflow.md
+++ b/.codex/pm/issue-state/33-add-repo-local-skill-for-issue-scoped-execution-workflow.md
@@ -1,0 +1,31 @@
+---
+type: issue_state
+issue: 33
+task: .codex/pm/tasks/repository-harness/add-repo-local-skill-for-issue-scoped-execution-workflow.md
+title: Add repo-local skill for issue-scoped execution workflow
+status: done
+---
+
+## Summary
+
+Add a repo-local skill that captures the correct issue-scoped execution sequence so future agent sessions do not need to reconstruct the workflow from memory.
+
+## Validated Facts
+
+- repeated agent friction came from workflow ordering rather than product code
+- the repository already has CCPM and guardrail primitives, but not one skill that sequences them for one issue
+- this capability belongs in progressively disclosed skills before more repository scripts are added
+
+## Open Questions
+
+- none
+
+## Next Steps
+
+- none; ready for PR
+
+## Artifacts
+
+- issue #33
+- `.codex/skills/harness-issue-execution/SKILL.md`
+- `AGENTS.md`

--- a/.codex/pm/tasks/repository-harness/add-repo-local-skill-for-issue-scoped-execution-workflow.md
+++ b/.codex/pm/tasks/repository-harness/add-repo-local-skill-for-issue-scoped-execution-workflow.md
@@ -1,0 +1,41 @@
+---
+type: task
+epic: repository-harness
+slug: add-repo-local-skill-for-issue-scoped-execution-workflow
+title: Add repo-local skill for issue-scoped execution workflow
+status: done
+task_type: implementation
+labels: tooling,feature
+issue: 33
+state_path: .codex/pm/issue-state/33-add-repo-local-skill-for-issue-scoped-execution-workflow.md
+---
+
+## Context
+
+Autonomous delivery sessions keep hitting the same workflow friction: branch setup, PM twin sync, review-proof ordering, preflight timing, and PR timing are all correct but too easy to get wrong when they depend on memory.
+
+
+## Deliverable
+
+Add a repo-local skill that gives agents one clear issue-scoped execution sequence from issue start through merge.
+
+
+## Scope
+
+- create a repository-local skill for one-issue execution
+- encode branch, task, issue-state, review/proof, preflight, push, PR, and merge ordering
+- expose the skill in agent guidance without expanding normal contributor-facing docs
+
+## Acceptance Criteria
+
+- the repository has a dedicated skill for issue-scoped execution
+- the skill covers the repeated timing mistakes observed in autonomous delivery
+- the guidance stays agent-oriented rather than becoming general repository scripting
+
+## Validation
+
+- manual review of the skill against the repository governance and CCPM flow
+
+## Implementation Notes
+
+Keep this skill narrow. A separate skill should handle multi-issue chaining.

--- a/.codex/skills/harness-issue-execution/SKILL.md
+++ b/.codex/skills/harness-issue-execution/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: harness-issue-execution
+description: Use for issue-scoped delivery work in this repository so the session follows the correct sequence for branch setup, task twin sync, review proof timing, preflight, PR creation, and merge.
+---
+
+# Harness Issue Execution
+
+Use this skill when implementing one specific GitHub issue in HarnessHub.
+
+Do not use this skill for broad planning or for chaining several issues in one session.
+
+## Goal
+
+Keep issue execution fast without relying on memory for repository workflow details.
+
+## Workflow
+
+1. Confirm the issue number and work only on that one issue.
+2. Start from the latest `upstream/main`.
+3. Create or switch to the dedicated issue branch:
+   - `issue-<n>-<slug>`
+4. Create or update the local task twin under `.codex/pm/tasks/`.
+5. Move the task to `in_progress`.
+6. Initialize issue-state when the work may span sessions.
+7. Implement only the scoped issue changes on that branch.
+8. Commit the issue changes before refreshing review proof.
+9. Refresh the review checkpoint:
+   - `npm run review:checkpoint`
+10. Update `.codex-review` after the proof refresh so the review note is newer than the proof file.
+11. Run local preflight:
+   - `./scripts/run-agent-preflight.sh`
+12. Push the branch.
+13. Open one PR that closes that issue only.
+14. Merge the PR.
+15. Stop using that branch after merge.
+
+## Timing Rules
+
+- Do not refresh `.codex-review-proof` before the issue commit exists.
+- Do not run preflight before `.codex-review` has been updated after the latest proof refresh.
+- Do not create the PR before the branch has been pushed and is visible on the remote.
+
+## Branch Rules
+
+- One issue per branch.
+- One issue per PR.
+- Do not continue work on a branch whose PR already merged.
+- If the current branch already has a merged PR, stop and create a new issue branch from `upstream/main`.
+
+## CCPM Rules
+
+- Keep the local task twin aligned with the remote issue.
+- Keep issue-state useful for handoff: validated facts, open questions, next steps, artifacts.
+- Mark the task `done` only when the issue branch is ready to land.
+
+## Validation Rules
+
+- Use `./scripts/run-cli-smoke.sh` when the issue changes documented command paths or import/export/verify behavior.
+- Keep preflight as the final local gate before PR creation or push.
+
+## Not This Skill
+
+- For repeated workflow failures that should become guardrails, use `harness-gap-closure`.
+- For broader task and PRD management, use `ccpm-codex`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ Harness and workflow support lives in:
 
 - `.codex/skills/ccpm-codex/` — local issue-task-PR workflow guidance
 - `.codex/skills/harness-gap-closure/` — convert repeated workflow failures into guardrails
+- `.codex/skills/harness-issue-execution/` — issue-scoped execution sequence for branch/task/review/preflight/PR/merge
 - `.codex/pm/` — local PRD/epic/task/state documents
 - `.githooks/pre-push` — local review/proof/closure guardrail
 - `scripts/` — PM, review checkpoint, preflight, and CLI smoke commands


### PR DESCRIPTION
Closes #33

This PR adds a repo-local `harness-issue-execution` skill for issue-scoped delivery sessions. Recent autonomous runs showed that the hardest repeated failures were not product bugs but workflow ordering mistakes: starting from the wrong branch base, refreshing review proof at the wrong time, running preflight in the wrong sequence, or opening a PR before the remote branch was visible.

The new skill captures the preferred one-issue workflow from branch start through merge, including branch rules, CCPM steps, review-proof timing, preflight timing, and PR timing. The guidance is deliberately agent-oriented and is exposed through `AGENTS.md` rather than through broader contributor-facing repository docs. The existing repository scripts remain the hard guardrails; this skill provides the progressively disclosed workflow layer above them.

Validation used for this change:

- `npm run build`
- `./scripts/run-agent-preflight.sh`
