### PR TITLE
[codex] Add multi-issue delivery skill

### DIFF
--- a/.codex/pm/issue-state/31-add-repo-local-skill-for-multi-issue-delivery-sessions.md
+++ b/.codex/pm/issue-state/31-add-repo-local-skill-for-multi-issue-delivery-sessions.md
@@ -1,0 +1,31 @@
+---
+type: issue_state
+issue: 31
+task: .codex/pm/tasks/repository-harness/add-repo-local-skill-for-multi-issue-delivery-sessions.md
+title: Add repo-local skill for multi-issue delivery sessions
+status: done
+---
+
+## Summary
+
+Add a repo-local skill for chaining several issue deliveries safely so autonomous sessions stop reusing merged branches or stale bases.
+
+## Validated Facts
+
+- multi-issue sessions need different workflow guidance than one-issue execution
+- the repeated mistakes are branch-lifecycle mistakes rather than product bugs
+- the repository already enforces one issue per branch; the skill should teach how to honor that rule across several issues
+
+## Open Questions
+
+- none
+
+## Next Steps
+
+- none; ready for PR
+
+## Artifacts
+
+- issue #31
+- `.codex/skills/harness-multi-issue-delivery/SKILL.md`
+- `AGENTS.md`

--- a/.codex/pm/tasks/repository-harness/add-repo-local-skill-for-multi-issue-delivery-sessions.md
+++ b/.codex/pm/tasks/repository-harness/add-repo-local-skill-for-multi-issue-delivery-sessions.md
@@ -1,0 +1,41 @@
+---
+type: task
+epic: repository-harness
+slug: add-repo-local-skill-for-multi-issue-delivery-sessions
+title: Add repo-local skill for multi-issue delivery sessions
+status: done
+task_type: implementation
+labels: tooling,feature
+issue: 31
+state_path: .codex/pm/issue-state/31-add-repo-local-skill-for-multi-issue-delivery-sessions.md
+---
+
+## Context
+
+When one session delivers several issues in a row, the repeated failure mode is not product logic. It is workflow drift: continuing on a merged branch, forgetting to resync from upstream, or letting issue scopes bleed together.
+
+
+## Deliverable
+
+Add a repo-local skill that explains how to sequence several issue branches safely in one session.
+
+
+## Scope
+
+- create a repository-local skill for multi-issue delivery sessions
+- encode when to return to latest `upstream/main` and when to start a fresh branch
+- keep the guidance aligned with the one-issue-per-branch rule
+
+## Acceptance Criteria
+
+- the repository has a dedicated skill for multi-issue delivery sequencing
+- the skill explicitly prevents merged-branch reuse and stale-base continuation
+- the guidance stays workflow-focused rather than changing product code
+
+## Validation
+
+- manual review against the repository governance and issue-branch rules
+
+## Implementation Notes
+
+Keep this skill separate from single-issue execution so the guidance stays narrow and composable.

--- a/.codex/skills/harness-multi-issue-delivery/SKILL.md
+++ b/.codex/skills/harness-multi-issue-delivery/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: harness-multi-issue-delivery
+description: Use when one session needs to deliver several HarnessHub issues in sequence without reusing merged branches or drifting from the latest upstream main.
+---
+
+# Harness Multi-Issue Delivery
+
+Use this skill when the session goal includes more than one issue branch.
+
+Do not use it for a single issue. For one issue at a time, use `harness-issue-execution`.
+
+## Goal
+
+Chain issue delivery safely without scope bleed, merged-branch reuse, or stale-base mistakes.
+
+## Sequence
+
+1. Decide the issue order up front.
+2. Treat each issue as a separate branch and a separate PR.
+3. After each merge:
+   - stop using the merged branch
+   - fetch `upstream`
+   - restart from the latest `upstream/main`
+4. Start the next issue on a fresh branch only after the previous issue is merged or deliberately paused.
+
+## Rules
+
+- Never append a new issue onto a branch whose PR already merged.
+- Never keep working on an outdated branch base when the previous issue already landed.
+- Keep one issue per branch and one issue per PR even if the same session handles several issues.
+- Keep local task twins separate and issue-scoped.
+
+## Recommended Loop
+
+For each issue in the session:
+
+1. Start from the latest `upstream/main`.
+2. Create the dedicated issue branch.
+3. Run the issue through `harness-issue-execution`.
+4. Merge the PR.
+5. Return to the latest `upstream/main`.
+6. Start the next issue fresh.
+
+## Handoff Rules
+
+- If you stop mid-session, record the current issue-state before switching context.
+- Do not leave several active issues half-implemented on one branch.
+- If work for the next issue depends on the previous PR merging, wait for the merge before continuing.
+
+## Not This Skill
+
+- For one issue at a time, use `harness-issue-execution`.
+- For repeated workflow failures that should become hard guardrails, use `harness-gap-closure`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ Harness and workflow support lives in:
 - `.codex/skills/ccpm-codex/` — local issue-task-PR workflow guidance
 - `.codex/skills/harness-gap-closure/` — convert repeated workflow failures into guardrails
 - `.codex/skills/harness-issue-execution/` — issue-scoped execution sequence for branch/task/review/preflight/PR/merge
+- `.codex/skills/harness-multi-issue-delivery/` — multi-issue session sequencing from merged branch back to fresh upstream/main
 - `.codex/pm/` — local PRD/epic/task/state documents
 - `.githooks/pre-push` — local review/proof/closure guardrail
 - `scripts/` — PM, review checkpoint, preflight, and CLI smoke commands


### PR DESCRIPTION
Closes #31

This PR adds a repo-local `harness-multi-issue-delivery` skill for sessions that need to land several issues in sequence. The main failure mode in those sessions was not code correctness. It was branch lifecycle drift: continuing on a merged branch, forgetting to return to the latest `upstream/main`, or letting issue scopes bleed into one another.

The new skill is deliberately separate from the single-issue execution skill. It explains how to order issues, when to return to `upstream/main`, when to start a fresh issue branch, and how to keep issue scope isolated across several deliveries in one session. This keeps the guidance progressively disclosed and workflow-oriented instead of adding more repository scripting.

Validation used for this change:

- `npm run build`
- `./scripts/run-agent-preflight.sh`
