### PR TITLE
[codex] Improve local PM twin hydration

### DIFF
--- a/.codex/pm/issue-state/32-improve-local-pm-twin-hydration-for-issue-scoped-work.md
+++ b/.codex/pm/issue-state/32-improve-local-pm-twin-hydration-for-issue-scoped-work.md
@@ -1,0 +1,32 @@
+---
+type: issue_state
+issue: 32
+task: .codex/pm/tasks/repository-harness/improve-local-pm-twin-hydration-for-issue-scoped-work.md
+title: Improve local PM twin hydration for issue-scoped work
+status: done
+---
+
+## Summary
+
+Improve local PM twin hydration so GitHub issue scope can be reflected into task and issue-state files with less manual copy-editing during implementation startup.
+
+The local CCPM harness has the right structure, but the startup cost is still too manual: task files and issue-state files begin mostly empty, then require repeated hand-filling before they become useful. That slows down autonomous sessions and creates more chances for drift between remote issue state and local PM state.
+
+## Validated Facts
+
+- creating a local task twin requires less manual follow-up to become useful
+- issue-state initialization reflects active issue context more directly
+- the improvement stays repository-local and does not change public product behavior
+
+## Open Questions
+
+-
+
+## Next Steps
+
+- monitor the hydrated task/issue-state flow during the next issue startup
+- extend hydration only if repeated manual gaps still appear in practice
+
+## Artifacts
+
+-

--- a/.codex/pm/tasks/repository-harness/improve-local-pm-twin-hydration-for-issue-scoped-work.md
+++ b/.codex/pm/tasks/repository-harness/improve-local-pm-twin-hydration-for-issue-scoped-work.md
@@ -1,0 +1,41 @@
+---
+type: task
+epic: repository-harness
+slug: improve-local-pm-twin-hydration-for-issue-scoped-work
+title: Improve local PM twin hydration for issue-scoped work
+status: done
+task_type: implementation
+labels: tooling,feature
+issue: 32
+state_path: .codex/pm/issue-state/32-improve-local-pm-twin-hydration-for-issue-scoped-work.md
+---
+
+## Context
+
+Improve local PM twin hydration so GitHub issue scope can be reflected into task and issue-state files with less manual copy-editing during implementation startup.
+
+The local CCPM harness has the right structure, but the startup cost is still too manual: task files and issue-state files begin mostly empty, then require repeated hand-filling before they become useful. That slows down autonomous sessions and creates more chances for drift between remote issue state and local PM state.
+
+## Deliverable
+
+Improve local PM twin hydration so GitHub issue scope can be reflected into task and issue-state files with less manual copy-editing during implementation startup.
+
+## Scope
+
+- improve repository-local PM workflows so new task twins can be hydrated from issue intent more effectively
+- reduce the amount of repeated manual boilerplate needed for Context, Scope, Acceptance Criteria, and Next Steps
+- keep the solution local to the repository harness and compatible with the current CCPM flow
+
+## Acceptance Criteria
+
+- creating a local task twin requires less manual follow-up to become useful
+- issue-state initialization reflects active issue context more directly
+- the improvement stays repository-local and does not change public product behavior
+
+## Validation
+
+- `npm test`
+- `npx vitest run test/codex-pm.test.ts`
+- `npm run build`
+
+## Implementation Notes

--- a/scripts/codex-pm.mjs
+++ b/scripts/codex-pm.mjs
@@ -143,14 +143,12 @@ function taskNew(args, io) {
     depends_on: options["depends-on"] ?? "",
   };
   if (options.issue) metadata.issue = options.issue;
-  writeDocument(taskPath, metadata, {
-    Context: "",
-    Deliverable: "",
-    Scope: "- ",
-    "Acceptance Criteria": "- ",
-    Validation: "- ",
-    "Implementation Notes": "",
-  });
+  writeDocument(taskPath, metadata, buildTaskSections({
+    title: options.title,
+    issue: options.issue,
+    issueBodyFile: options["issue-body-file"],
+    repo: options.repo,
+  }));
   io.log(taskPath);
   return 0;
 }
@@ -475,13 +473,7 @@ export function initIssueState(taskDocument) {
       task: taskDocument.path,
       title: taskDocument.metadata.title ?? "",
       status: taskDocument.metadata.status ?? "",
-    }, {
-      Summary: "Record the current working state for this issue so later sessions do not have to rediscover it.",
-      "Validated Facts": "- ",
-      "Open Questions": "- ",
-      "Next Steps": "- ",
-      Artifacts: "- ",
-    });
+    }, buildIssueStateSections(taskDocument));
   }
   taskDocument.metadata.state_path = filePath;
   persistDocument(taskDocument);
@@ -632,6 +624,30 @@ export function verifyClosureSync(prBody, changedFiles) {
   return errors;
 }
 
+function buildTaskSections({ title, issue, issueBodyFile, repo }) {
+  const hydrated = hydrateTaskFromIssue({ issue, issueBodyFile, repo });
+  const contextParts = [hydrated.Summary, hydrated.Why].filter(Boolean);
+  return {
+    Context: contextParts.join("\n\n"),
+    Deliverable: hydrated.Summary || title || "",
+    Scope: asBulletList(hydrated.Scope),
+    "Acceptance Criteria": asBulletList(hydrated["Acceptance Criteria"]),
+    Validation: "- ",
+    "Implementation Notes": "",
+  };
+}
+
+function buildIssueStateSections(taskDocument) {
+  const context = taskDocument.sections.Context || taskDocument.sections.Deliverable || taskDocument.metadata.title || "";
+  return {
+    Summary: context || "Record the current working state for this issue so later sessions do not have to rediscover it.",
+    "Validated Facts": asBulletList(taskDocument.sections["Acceptance Criteria"]),
+    "Open Questions": "- ",
+    "Next Steps": asBulletList(taskDocument.sections.Scope),
+    Artifacts: "- ",
+  };
+}
+
 function resolvePrBody(options) {
   if (options["pr-body"]) return options["pr-body"];
   if (options["event-path"]) {
@@ -649,6 +665,60 @@ function resolveChangedFiles(options) {
     return result.stdout.split("\n").map((line) => line.trim()).filter(Boolean);
   }
   throw new Error("either --changed-file or both --base-sha and --head-sha are required");
+}
+
+function hydrateTaskFromIssue({ issue, issueBodyFile, repo }) {
+  if (issueBodyFile) {
+    return parseIssueSections(fs.readFileSync(issueBodyFile, "utf8"));
+  }
+  const issueNumber = parseIssueNumber(String(issue ?? ""));
+  if (issueNumber === null) {
+    return {};
+  }
+  const issueBody = loadGithubIssueBody(issueNumber, repo);
+  return issueBody ? parseIssueSections(issueBody) : {};
+}
+
+function loadGithubIssueBody(issueNumber, repo) {
+  const resolvedRepo = repo ?? inferBaseRepo();
+  const args = ["issue", "view", String(issueNumber), "--json", "body"];
+  if (resolvedRepo) args.push("--repo", resolvedRepo);
+  const result = spawnSync("gh", args, { encoding: "utf8" });
+  if (result.status !== 0) {
+    return "";
+  }
+  try {
+    return JSON.parse(result.stdout).body ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function parseIssueSections(markdown) {
+  const sections = {};
+  let currentHeading = null;
+  const currentLines = [];
+  const flush = () => {
+    if (!currentHeading) return;
+    sections[currentHeading] = currentLines.join("\n").trim();
+    currentLines.length = 0;
+  };
+  for (const line of markdown.split("\n")) {
+    if (line.startsWith("## ")) {
+      flush();
+      currentHeading = line.slice(3).trim();
+      continue;
+    }
+    if (currentHeading) currentLines.push(line);
+  }
+  flush();
+  return sections;
+}
+
+function asBulletList(value) {
+  const trimmed = String(value ?? "").trim();
+  if (!trimmed) return "- ";
+  return trimmed;
 }
 
 function currentBranch() {

--- a/test/codex-pm.test.ts
+++ b/test/codex-pm.test.ts
@@ -83,4 +83,53 @@ describe("codex-pm", () => {
       path.relative(tmpDir, taskPath),
     ])).toBe(0);
   });
+
+  it("hydrates task twins and issue state from issue intent", () => {
+    expect(main(["init"])).toBe(0);
+    const issueBodyPath = path.join(tmpDir, "issue-body.md");
+    fs.writeFileSync(issueBodyPath, [
+      "## Summary",
+      "Improve local PM twin hydration so startup requires less copy-editing.",
+      "",
+      "## Why",
+      "The local twin structure exists, but initial files are too empty to guide implementation.",
+      "",
+      "## Scope",
+      "- hydrate Context from issue intent",
+      "- hydrate Scope and Acceptance Criteria",
+      "",
+      "## Acceptance Criteria",
+      "- task twins start useful",
+      "- issue-state next steps reflect scope",
+      "",
+    ].join("\n"), "utf8");
+
+    expect(main([
+      "task-new",
+      "repository-harness",
+      "pm-hydration",
+      "--title",
+      "Improve local PM twin hydration",
+      "--issue",
+      "32",
+      "--issue-body-file",
+      issueBodyPath,
+    ])).toBe(0);
+
+    const taskPath = path.join(tmpDir, ".codex", "pm", "tasks", "repository-harness", "pm-hydration.md");
+    const taskText = fs.readFileSync(taskPath, "utf8");
+    expect(taskText).toContain("Improve local PM twin hydration so startup requires less copy-editing.");
+    expect(taskText).toContain("The local twin structure exists, but initial files are too empty to guide implementation.");
+    expect(taskText).toContain("- hydrate Scope and Acceptance Criteria");
+
+    expect(main(["set-status", taskPath, "in_progress"])).toBe(0);
+    expect(main(["issue-state-init", taskPath])).toBe(0);
+
+    const statePath = path.join(tmpDir, ".codex", "pm", "issue-state", "32-pm-hydration.md");
+    const stateText = fs.readFileSync(statePath, "utf8");
+    expect(stateText).toContain("Improve local PM twin hydration so startup requires less copy-editing.");
+    expect(stateText).toContain("- hydrate Context from issue intent");
+    expect(stateText).toContain("- task twins start useful");
+    expect(stateText).toContain("status: in_progress");
+  });
 });


### PR DESCRIPTION
Closes #32

Improve local PM twin hydration so GitHub issue scope can be reflected into task and issue-state files with less manual copy-editing during implementation startup.

Validation:
- `npm test`
- `npx vitest run test/codex-pm.test.ts`
- `npm run build`
- `npm run build`
- `npm test`