### PR TITLE
[codex] Block merged-PR branch reuse earlier in preflight

### DIFF
--- a/.codex/pm/issue-state/38-block-continued-work-on-branches-whose-pr-has-already-merged.md
+++ b/.codex/pm/issue-state/38-block-continued-work-on-branches-whose-pr-has-already-merged.md
@@ -1,0 +1,32 @@
+---
+type: issue_state
+issue: 38
+task: .codex/pm/tasks/repository-harness/block-continued-work-on-branches-whose-pr-has-already-merged.md
+title: Block continued work on branches whose PR has already merged
+status: done
+---
+
+## Summary
+
+Add a local harness guardrail that blocks continued work on a branch once its associated pull request has already merged.
+
+A merged issue branch should be treated as closed delivery state, but it is still easy to keep making changes locally and only realize the mistake later. That creates cleanup work, risks mixed-scope commits, and weakens the one-issue-per-branch rule.
+
+## Validated Facts
+
+- local harness flow blocks continued delivery work on branches whose PR has already merged
+- the failure message makes the next correct action obvious
+- the guardrail remains local and does not change public product behavior
+
+## Open Questions
+
+-
+
+## Next Steps
+
+- confirm the same merged-branch rule remains enforced in both preflight and pre-push
+- treat any later branch-reuse regression as a new harness gap
+
+## Artifacts
+
+-

--- a/.codex/pm/tasks/repository-harness/block-continued-work-on-branches-whose-pr-has-already-merged.md
+++ b/.codex/pm/tasks/repository-harness/block-continued-work-on-branches-whose-pr-has-already-merged.md
@@ -1,0 +1,41 @@
+---
+type: task
+epic: repository-harness
+slug: block-continued-work-on-branches-whose-pr-has-already-merged
+title: Block continued work on branches whose PR has already merged
+status: done
+task_type: implementation
+labels: tooling,guardrail
+issue: 38
+state_path: .codex/pm/issue-state/38-block-continued-work-on-branches-whose-pr-has-already-merged.md
+---
+
+## Context
+
+Add a local harness guardrail that blocks continued work on a branch once its associated pull request has already merged.
+
+A merged issue branch should be treated as closed delivery state, but it is still easy to keep making changes locally and only realize the mistake later. That creates cleanup work, risks mixed-scope commits, and weakens the one-issue-per-branch rule.
+
+## Deliverable
+
+Add a local harness guardrail that blocks continued work on a branch once its associated pull request has already merged.
+
+## Scope
+
+- detect when the current issue branch already has a merged pull request
+- surface the failure early in local harness flow rather than after more work accumulates
+- keep the solution repository-local and compatible with the current issue-task-PR workflow
+
+## Acceptance Criteria
+
+- local harness flow blocks continued delivery work on branches whose PR has already merged
+- the failure message makes the next correct action obvious
+- the guardrail remains local and does not change public product behavior
+
+## Validation
+
+- `npm run build`
+- `npm test`
+- `./scripts/run-agent-preflight.sh`
+
+## Implementation Notes

--- a/docs/engineering/tooling-setup.md
+++ b/docs/engineering/tooling-setup.md
@@ -48,7 +48,7 @@ For the standard local readiness pass before push, run:
 ./scripts/run-agent-preflight.sh
 ```
 
-This checks the local review note, review proof, issue-state, build, tests, and local PR closure sync when `gh` can resolve the current PR body.
+This checks the local review note, review proof, merged-branch reuse, issue-state, build, tests, and local PR closure sync when `gh` can resolve the current PR body.
 
 A normal issue-scoped path is:
 

--- a/scripts/run-agent-preflight.sh
+++ b/scripts/run-agent-preflight.sh
@@ -19,6 +19,26 @@ ENFORCE_ISSUE_STATE="${HARNESSHUB_PREFLIGHT_ENFORCE_ISSUE_STATE:-${CLAWPACK_PREF
 BUILD_COMMAND="${HARNESSHUB_PREFLIGHT_BUILD_COMMAND:-${CLAWPACK_PREFLIGHT_BUILD_COMMAND:-npm run build}}"
 TEST_COMMAND="${HARNESSHUB_PREFLIGHT_TEST_COMMAND:-${CLAWPACK_PREFLIGHT_TEST_COMMAND:-npm test}}"
 SMOKE_COMMAND="${HARNESSHUB_PREFLIGHT_SMOKE_COMMAND:-${CLAWPACK_PREFLIGHT_SMOKE_COMMAND:-./scripts/run-cli-smoke.sh}}"
+ORIGIN_URL="$(git remote get-url origin 2>/dev/null || true)"
+UPSTREAM_URL="$(git remote get-url upstream 2>/dev/null || true)"
+
+extract_repo() {
+  local remote_url="$1"
+  if [[ "$remote_url" =~ github\.com[:/]([^/]+)/([^/.]+?)(\.git)?$ ]]; then
+    echo "${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+    return 0
+  fi
+  return 1
+}
+
+extract_owner() {
+  local remote_url="$1"
+  if [[ "$remote_url" =~ github\.com[:/]([^/]+)/[^/]+(\.git)?$ ]]; then
+    echo "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  return 1
+}
 
 read_review_proof_value() {
   local key="$1"
@@ -126,6 +146,40 @@ check_issue_state() {
   echo "Continuing without enforced issue-state check. Set HARNESSHUB_PREFLIGHT_ENFORCE_ISSUE_STATE=1 to require it."
 }
 
+check_merged_pr_branch_reuse() {
+  local current_branch owner base_repo merged_pr_json
+  current_branch="$(git branch --show-current)"
+
+  if [[ -z "$current_branch" ]]; then
+    return 0
+  fi
+
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "Skipping merged-branch check: gh is unavailable"
+    return 0
+  fi
+
+  if ! owner="$(extract_owner "$ORIGIN_URL")" || ! base_repo="$(extract_repo "$UPSTREAM_URL")"; then
+    echo "Skipping merged-branch check: GitHub remotes are unavailable"
+    return 0
+  fi
+
+  merged_pr_json="$(
+    gh pr list \
+      --repo "$base_repo" \
+      --head "$owner:$current_branch" \
+      --state merged \
+      --json number,url \
+      2>/dev/null || true
+  )"
+
+  if [[ "$merged_pr_json" != "[]" ]] && [[ -n "$merged_pr_json" ]]; then
+    echo "Preflight failed: the current branch already has a merged PR in $base_repo"
+    echo "Create a new branch from $BASE_REF for follow-up work instead of continuing on $current_branch."
+    exit 1
+  fi
+}
+
 run_local_pr_closure_check() {
   local changed_files pr_body body_input=()
 
@@ -161,6 +215,7 @@ run_local_pr_closure_check() {
 echo "Running agent preflight in $ROOT_DIR"
 
 check_branch_freshness
+check_merged_pr_branch_reuse
 check_review_note
 check_review_proof
 check_issue_state

--- a/test/preflight-script.test.ts
+++ b/test/preflight-script.test.ts
@@ -87,4 +87,44 @@ describe("run-agent-preflight.sh", () => {
     expect(result.stdout).toContain("Agent preflight passed.");
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
+
+  it("blocks reusing a branch whose PR already merged", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "harnesshub-preflight-"));
+    const branch = spawnSync("git", ["branch", "--show-current"], { cwd: repoRoot, encoding: "utf8" }).stdout.trim();
+    const headSha = spawnSync("git", ["rev-parse", "HEAD"], { cwd: repoRoot, encoding: "utf8" }).stdout.trim();
+    const binDir = path.join(tmpDir, "bin");
+    fs.mkdirSync(binDir);
+    fs.writeFileSync(path.join(binDir, "gh"), `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  echo '[{"number":41,"url":"https://github.com/HarnessHub/HarnessHub/pull/41"}]'
+  exit 0
+fi
+echo "unexpected gh invocation: $*" >&2
+exit 1
+`, "utf8");
+    fs.chmodSync(path.join(binDir, "gh"), 0o755);
+
+    fs.writeFileSync(path.join(tmpDir, ".codex-review-proof"), `branch=${branch}\nhead_sha=${headSha}\nbase_ref=HEAD\ngenerated_at=2026-03-12T00:00:00Z\n`, "utf8");
+    fs.writeFileSync(path.join(tmpDir, ".codex-review"), `scope reviewed: preflight\nhead reviewed: ${headSha}\nfindings: no findings\nremaining risks: smoke skipped\n`, "utf8");
+
+    const result = spawnSync("./scripts/run-agent-preflight.sh", [], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH}`,
+        HARNESSHUB_REVIEW_FILE: path.join(tmpDir, ".codex-review"),
+        HARNESSHUB_REVIEW_PROOF_FILE: path.join(tmpDir, ".codex-review-proof"),
+        HARNESSHUB_PREFLIGHT_BASE_REF: "HEAD",
+        HARNESSHUB_PREFLIGHT_BUILD_COMMAND: "true",
+        HARNESSHUB_PREFLIGHT_TEST_COMMAND: "true",
+        HARNESSHUB_PREFLIGHT_ACTIVE: "0",
+      },
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("already has a merged PR");
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
 });


### PR DESCRIPTION
Closes #38

Add a local harness guardrail that blocks continued work on a branch once its associated pull request has already merged.

Validation:
- `npm run build`
- `npm test`
- `./scripts/run-agent-preflight.sh`
- `npm run build`
- `npm test`