### PR TITLE
[codex] Validate OpenClaw packaging with a real artifact

### DIFF
--- a/.codex/pm/issue-state/39-validate-openclaw-end-to-end-packaging-flow-with-a-real-harness-artifact.md
+++ b/.codex/pm/issue-state/39-validate-openclaw-end-to-end-packaging-flow-with-a-real-harness-artifact.md
@@ -1,0 +1,34 @@
+---
+type: issue_state
+issue: 39
+task: .codex/pm/tasks/product-direction/validate-openclaw-end-to-end-packaging-flow-with-a-real-harness-artifact.md
+title: Validate OpenClaw end-to-end packaging flow with a real harness artifact
+status: done
+---
+
+## Summary
+
+Run an end-to-end OpenClaw packaging validation against a real local instance and produce an actual `.harness` artifact that can be inspected as proof that the current packaging flow works in practice.
+
+Before pushing toward a second runtime family, HarnessHub needs proof that the current OpenClaw-oriented flow works end to end outside unit tests. A real exported artifact and verified import path will expose gaps in packaging, import, verification, and documentation far better than abstract architecture work alone.
+
+## Validated Facts
+
+- an actual `.harness` artifact is produced from a real OpenClaw-shaped environment
+- import and verify succeed against that artifact in a clean target location
+- the resulting validation record is stored in-repo so later work can build on concrete evidence instead of assumptions
+
+## Open Questions
+
+-
+
+## Next Steps
+
+- reuse `./scripts/run-openclaw-e2e-validation.sh` for future OpenClaw regression checks
+- treat any future OpenClaw adapter changes as needing a fresh artifact and updated validation record
+
+## Artifacts
+
+- `.artifacts/openclaw-e2e/20260312T063701Z/openclaw-template.harness`
+- `docs/validation/openclaw-e2e-validation.md`
+- `docs/validation/openclaw-e2e-validation.json`

--- a/.codex/pm/tasks/product-direction/validate-openclaw-end-to-end-packaging-flow-with-a-real-harness-artifact.md
+++ b/.codex/pm/tasks/product-direction/validate-openclaw-end-to-end-packaging-flow-with-a-real-harness-artifact.md
@@ -1,0 +1,46 @@
+---
+type: task
+epic: product-direction
+slug: validate-openclaw-end-to-end-packaging-flow-with-a-real-harness-artifact
+title: Validate OpenClaw end-to-end packaging flow with a real harness artifact
+status: done
+task_type: implementation
+labels: feature,test
+issue: 39
+state_path: .codex/pm/issue-state/39-validate-openclaw-end-to-end-packaging-flow-with-a-real-harness-artifact.md
+---
+
+## Context
+
+Run an end-to-end OpenClaw packaging validation against a real local instance and produce an actual `.harness` artifact that can be inspected as proof that the current packaging flow works in practice.
+
+Before pushing toward a second runtime family, HarnessHub needs proof that the current OpenClaw-oriented flow works end to end outside unit tests. A real exported artifact and verified import path will expose gaps in packaging, import, verification, and documentation far better than abstract architecture work alone.
+
+## Deliverable
+
+Run an end-to-end OpenClaw packaging validation against a real local instance and produce an actual `.harness` artifact that can be inspected as proof that the current packaging flow works in practice.
+
+## Scope
+
+- select or construct a representative local OpenClaw instance for end-to-end validation
+- run inspect, export, import, and verify through the current `harness` CLI flow
+- retain a concrete artifact summary and validation record that proves the flow succeeded in practice
+- keep this focused on validating the existing OpenClaw path rather than expanding product scope to a new runtime
+
+## Acceptance Criteria
+
+- an actual `.harness` artifact is produced from a real OpenClaw-shaped environment
+- import and verify succeed against that artifact in a clean target location
+- the resulting validation record is stored in-repo so later work can build on concrete evidence instead of assumptions
+
+## Validation
+
+- `./scripts/run-openclaw-e2e-validation.sh`
+- `npm test`
+- `./scripts/run-agent-preflight.sh`
+
+## Implementation Notes
+
+Latest retained local artifact:
+
+- `.artifacts/openclaw-e2e/20260312T063701Z/openclaw-template.harness`

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ Thumbs.db
 .env.*
 .codex-review
 .codex-review-proof
+.artifacts/
 
 # Coverage
 coverage/

--- a/docs/validation/openclaw-e2e-validation.json
+++ b/docs/validation/openclaw-e2e-validation.json
@@ -1,0 +1,99 @@
+{
+  "validatedAt": "2026-03-12T06:37:07.412Z",
+  "sourceDir": "~/.openclaw",
+  "artifactPath": ".artifacts/openclaw-e2e/20260312T063701Z/openclaw-template.harness",
+  "artifactSha256": "e15876aa51aef57ba57828481ce457a9adffe95610e3ceeccfdc37707e384cb4",
+  "artifactSizeBytes": 4154926,
+  "inspect": {
+    "detected": true,
+    "product": "openclaw",
+    "configPath": "openclaw.json",
+    "recommendedPackType": "instance",
+    "riskAssessment": "trusted-migration-only",
+    "workspaceDirs": [
+      "workspace"
+    ],
+    "workspaceFileCount": 165,
+    "skillDirCount": 18,
+    "agentIds": [
+      "main"
+    ],
+    "warnings": [
+      "Config contains API keys or tokens",
+      "Agent auth-profiles.json detected (contains API credentials)",
+      "Credentials directory exists"
+    ]
+  },
+  "export": {
+    "success": true,
+    "packId": "64ceb066-b454-46b4-8755-88383a5817ab",
+    "packType": "template",
+    "riskLevel": "internal-only",
+    "fileCount": 343,
+    "totalSize": 7279282
+  },
+  "manifest": {
+    "schemaVersion": "0.5.0",
+    "image": {
+      "imageId": "64ceb066-b454-46b4-8755-88383a5817ab",
+      "adapter": "openclaw"
+    },
+    "lineage": {
+      "parentImage": null,
+      "layerOrder": []
+    },
+    "harness": {
+      "intent": "agent-runtime-environment",
+      "targetProduct": "openclaw",
+      "components": [
+        "workspace",
+        "config",
+        "skills",
+        "agents",
+        "sessions",
+        "cron",
+        "extensions",
+        "browser",
+        "completions"
+      ]
+    },
+    "bindingWorkspaceCount": 1,
+    "source": {
+      "product": "openclaw",
+      "version": "unknown",
+      "configPath": "openclaw.json"
+    }
+  },
+  "import": {
+    "success": true,
+    "targetDir": ".artifacts/openclaw-e2e/20260312T063701Z/imported",
+    "fileCount": 344,
+    "warnings": [
+      "Rebound workspace paths in openclaw.json to ./.artifacts/openclaw-e2e/20260312T063701Z/imported; JSON5 formatting/comments were normalized."
+    ]
+  },
+  "verify": {
+    "valid": true,
+    "checkNames": [
+      "directory_exists",
+      "config_exists",
+      "workspace_exists",
+      "workspace_file_agents.md",
+      "config_valid",
+      "agents_present",
+      "manifest_schema",
+      "manifest_pack_type",
+      "manifest_image",
+      "manifest_lineage",
+      "manifest_harness",
+      "workspace_bindings",
+      "binding_semantics",
+      "file_count",
+      "workspace_readable"
+    ],
+    "warnings": [
+      "Agent \"main\" missing agent/ subdirectory"
+    ],
+    "errors": []
+  }
+}

--- a/docs/validation/openclaw-e2e-validation.md
+++ b/docs/validation/openclaw-e2e-validation.md
@@ -1,0 +1,58 @@
+# OpenClaw End-to-End Validation
+
+This record comes from a real local `~/.openclaw` validation run using the current `harness` CLI path.
+
+- Validated at: `2026-03-12T06:37:07.412Z`
+- Source directory: `~/.openclaw`
+- Artifact path: `.artifacts/openclaw-e2e/20260312T063701Z/openclaw-template.harness`
+- Artifact sha256: `e15876aa51aef57ba57828481ce457a9adffe95610e3ceeccfdc37707e384cb4`
+- Artifact size: `4154926` bytes
+
+## Inspect
+
+- Detected: `true`
+- Product: `openclaw`
+- Config file: `openclaw.json`
+- Recommended pack type: `instance`
+- Risk assessment: `trusted-migration-only`
+- Workspace dirs: `workspace`
+- Workspace file count: `165`
+- Skill dir count: `18`
+- Agent ids: `main`
+
+## Export
+
+- Success: `true`
+- Pack ID: `64ceb066-b454-46b4-8755-88383a5817ab`
+- Pack type: `template`
+- Risk level: `internal-only`
+- File count: `343`
+- Total size: `7279282` bytes
+
+## Manifest
+
+- Schema version: `0.5.0`
+- Adapter: `openclaw`
+- Image ID: `64ceb066-b454-46b4-8755-88383a5817ab`
+- Binding workspace count: `1`
+- Harness intent: `agent-runtime-environment`
+- Harness target product: `openclaw`
+- Harness components: `workspace, config, skills, agents, sessions, cron, extensions, browser, completions`
+
+## Import And Verify
+
+- Import success: `true`
+- Imported target: `.artifacts/openclaw-e2e/20260312T063701Z/imported`
+- Imported file count: `344`
+- Verify valid: `true`
+- Verify checks: `directory_exists, config_exists, workspace_exists, workspace_file_agents.md, config_valid, agents_present, manifest_schema, manifest_pack_type, manifest_image, manifest_lineage, manifest_harness, workspace_bindings, binding_semantics, file_count, workspace_readable`
+
+## Warnings
+
+- Inspect: Config contains API keys or tokens
+- Inspect: Agent auth-profiles.json detected (contains API credentials)
+- Inspect: Credentials directory exists
+- Import: Rebound workspace paths in openclaw.json to ./.artifacts/openclaw-e2e/20260312T063701Z/imported; JSON5 formatting/comments were normalized.
+- Verify: Agent "main" missing agent/ subdirectory
+
+The `.harness` artifact itself is retained only in the local `.artifacts/` directory and is intentionally not committed.

--- a/scripts/run-openclaw-e2e-validation.sh
+++ b/scripts/run-openclaw-e2e-validation.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+SOURCE_DIR="${HARNESSHUB_OPENCLAW_E2E_SOURCE_DIR:-$HOME/.openclaw}"
+TIMESTAMP="$(date -u +"%Y%m%dT%H%M%SZ")"
+RUN_DIR="${HARNESSHUB_OPENCLAW_E2E_RUN_DIR:-$ROOT_DIR/.artifacts/openclaw-e2e/$TIMESTAMP}"
+PACK_FILE="$RUN_DIR/openclaw-template.harness"
+TARGET_DIR="$RUN_DIR/imported"
+REPORT_JSON="${HARNESSHUB_OPENCLAW_E2E_REPORT_JSON:-$ROOT_DIR/docs/validation/openclaw-e2e-validation.json}"
+REPORT_MD="${HARNESSHUB_OPENCLAW_E2E_REPORT_MD:-$ROOT_DIR/docs/validation/openclaw-e2e-validation.md}"
+
+if [[ ! -d "$SOURCE_DIR" ]]; then
+  echo "OpenClaw e2e validation failed: source directory not found: $SOURCE_DIR" >&2
+  exit 1
+fi
+
+mkdir -p "$RUN_DIR" "$(dirname "$REPORT_JSON")" "$(dirname "$REPORT_MD")"
+
+npm run build >/dev/null
+
+node dist/cli.js inspect -p "$SOURCE_DIR" -f json >"$RUN_DIR/inspect.json"
+node dist/cli.js export -p "$SOURCE_DIR" -o "$PACK_FILE" -t template -f json >"$RUN_DIR/export.json"
+node dist/cli.js import "$PACK_FILE" -t "$TARGET_DIR" -f json >"$RUN_DIR/import.json"
+node dist/cli.js verify -p "$TARGET_DIR" -f json >"$RUN_DIR/verify.json"
+tar -xOf "$PACK_FILE" manifest.json >"$RUN_DIR/manifest.json"
+sha256sum "$PACK_FILE" >"$RUN_DIR/sha256.txt"
+
+node - "$ROOT_DIR" "$SOURCE_DIR" "$RUN_DIR" "$REPORT_JSON" "$REPORT_MD" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+
+const [rootDir, sourceDir, runDir, reportJsonPath, reportMdPath] = process.argv.slice(2);
+const inspect = JSON.parse(fs.readFileSync(path.join(runDir, "inspect.json"), "utf8"));
+const exported = JSON.parse(fs.readFileSync(path.join(runDir, "export.json"), "utf8"));
+const imported = JSON.parse(fs.readFileSync(path.join(runDir, "import.json"), "utf8"));
+const verify = JSON.parse(fs.readFileSync(path.join(runDir, "verify.json"), "utf8"));
+const manifest = JSON.parse(fs.readFileSync(path.join(runDir, "manifest.json"), "utf8"));
+const sha256Line = fs.readFileSync(path.join(runDir, "sha256.txt"), "utf8").trim();
+const sha256 = sha256Line.split(/\s+/)[0];
+const artifactStat = fs.statSync(path.join(runDir, "openclaw-template.harness"));
+const readableSourceDir = sourceDir.startsWith(process.env.HOME || "")
+  ? sourceDir.replace(process.env.HOME, "~")
+  : sourceDir;
+const relativeRunDir = path.relative(rootDir, runDir) || ".";
+const sanitizeText = (value) => String(value)
+  .replaceAll(rootDir, ".")
+  .replaceAll(runDir, relativeRunDir)
+  .replaceAll(sourceDir, readableSourceDir);
+const summary = {
+  validatedAt: new Date().toISOString(),
+  sourceDir: readableSourceDir,
+  artifactPath: path.join(relativeRunDir, "openclaw-template.harness"),
+  artifactSha256: sha256,
+  artifactSizeBytes: artifactStat.size,
+  inspect: {
+    detected: inspect.detected,
+    product: inspect.product,
+    configPath: inspect.configPath ? path.basename(inspect.configPath) : null,
+    recommendedPackType: inspect.recommendedPackType,
+    riskAssessment: inspect.riskAssessment,
+    workspaceDirs: inspect.structure?.workspaceDirs ?? [],
+    workspaceFileCount: inspect.structure?.workspaceFiles?.length ?? 0,
+    skillDirCount: inspect.structure?.skillDirs?.length ?? 0,
+    agentIds: inspect.structure?.agentIds ?? [],
+    warnings: (inspect.warnings ?? []).map(sanitizeText),
+  },
+  export: {
+    success: exported.success,
+    packId: exported.packId,
+    packType: exported.packType,
+    riskLevel: exported.riskLevel,
+    fileCount: exported.fileCount,
+    totalSize: exported.totalSize,
+  },
+  manifest: {
+    schemaVersion: manifest.schemaVersion,
+    image: manifest.image,
+    lineage: manifest.lineage,
+    harness: manifest.harness,
+    bindingWorkspaceCount: manifest.bindings?.workspaces?.length ?? 0,
+    source: manifest.source,
+  },
+  import: {
+    success: imported.success,
+    targetDir: path.join(relativeRunDir, "imported"),
+    fileCount: imported.fileCount,
+    warnings: (imported.warnings ?? []).map(sanitizeText),
+  },
+  verify: {
+    valid: verify.valid,
+    checkNames: (verify.checks ?? []).map((check) => check.name),
+    warnings: (verify.warnings ?? []).map(sanitizeText),
+    errors: (verify.errors ?? []).map(sanitizeText),
+  },
+};
+
+fs.writeFileSync(reportJsonPath, JSON.stringify(summary, null, 2) + "\n", "utf8");
+
+const md = [
+  "# OpenClaw End-to-End Validation",
+  "",
+  "This record comes from a real local `~/.openclaw` validation run using the current `harness` CLI path.",
+  "",
+  `- Validated at: \`${summary.validatedAt}\``,
+  `- Source directory: \`${summary.sourceDir}\``,
+  `- Artifact path: \`${summary.artifactPath}\``,
+  `- Artifact sha256: \`${summary.artifactSha256}\``,
+  `- Artifact size: \`${summary.artifactSizeBytes}\` bytes`,
+  "",
+  "## Inspect",
+  "",
+  `- Detected: \`${summary.inspect.detected}\``,
+  `- Product: \`${summary.inspect.product}\``,
+  `- Config file: \`${summary.inspect.configPath}\``,
+  `- Recommended pack type: \`${summary.inspect.recommendedPackType}\``,
+  `- Risk assessment: \`${summary.inspect.riskAssessment}\``,
+  `- Workspace dirs: \`${summary.inspect.workspaceDirs.join(", ")}\``,
+  `- Workspace file count: \`${summary.inspect.workspaceFileCount}\``,
+  `- Skill dir count: \`${summary.inspect.skillDirCount}\``,
+  `- Agent ids: \`${summary.inspect.agentIds.join(", ")}\``,
+  "",
+  "## Export",
+  "",
+  `- Success: \`${summary.export.success}\``,
+  `- Pack ID: \`${summary.export.packId}\``,
+  `- Pack type: \`${summary.export.packType}\``,
+  `- Risk level: \`${summary.export.riskLevel}\``,
+  `- File count: \`${summary.export.fileCount}\``,
+  `- Total size: \`${summary.export.totalSize}\` bytes`,
+  "",
+  "## Manifest",
+  "",
+  `- Schema version: \`${summary.manifest.schemaVersion}\``,
+  `- Adapter: \`${summary.manifest.image.adapter}\``,
+  `- Image ID: \`${summary.manifest.image.imageId}\``,
+  `- Binding workspace count: \`${summary.manifest.bindingWorkspaceCount}\``,
+  `- Harness intent: \`${summary.manifest.harness.intent}\``,
+  `- Harness target product: \`${summary.manifest.harness.targetProduct}\``,
+  `- Harness components: \`${summary.manifest.harness.components.join(", ")}\``,
+  "",
+  "## Import And Verify",
+  "",
+  `- Import success: \`${summary.import.success}\``,
+  `- Imported target: \`${summary.import.targetDir}\``,
+  `- Imported file count: \`${summary.import.fileCount}\``,
+  `- Verify valid: \`${summary.verify.valid}\``,
+  `- Verify checks: \`${summary.verify.checkNames.join(", ")}\``,
+  "",
+  "## Warnings",
+  "",
+  ...(summary.inspect.warnings.length > 0 ? summary.inspect.warnings.map((warning) => `- Inspect: ${warning}`) : ["- Inspect: none"]),
+  ...(summary.import.warnings.length > 0 ? summary.import.warnings.map((warning) => `- Import: ${warning}`) : ["- Import: none"]),
+  ...(summary.verify.warnings.length > 0 ? summary.verify.warnings.map((warning) => `- Verify: ${warning}`) : ["- Verify: none"]),
+  "",
+  "The `.harness` artifact itself is retained only in the local `.artifacts/` directory and is intentionally not committed.",
+  "",
+];
+
+fs.writeFileSync(reportMdPath, md.join("\n"), "utf8");
+NODE
+
+echo "OpenClaw e2e validation complete."
+echo "Artifact: $PACK_FILE"
+echo "Report:   $REPORT_MD"

--- a/test/openclaw-e2e-script.test.ts
+++ b/test/openclaw-e2e-script.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function createOpenClawFixture(dir: string) {
+  fs.mkdirSync(path.join(dir, "workspace", "skills", "demo"), { recursive: true });
+  fs.mkdirSync(path.join(dir, "agents", "main", "sessions"), { recursive: true });
+  fs.mkdirSync(path.join(dir, "identity"), { recursive: true });
+
+  fs.writeFileSync(path.join(dir, "openclaw.json"), JSON.stringify({
+    agents: {
+      defaults: { workspace: "./workspace" },
+      list: [{ id: "main", default: true, workspace: "./workspace" }],
+    },
+  }, null, 2));
+  fs.writeFileSync(path.join(dir, "workspace", "AGENTS.md"), "# Demo Agent\n");
+  fs.writeFileSync(path.join(dir, "workspace", "SOUL.md"), "# Demo Soul\n");
+  fs.writeFileSync(path.join(dir, "workspace", "skills", "demo", "SKILL.md"), "---\nname: demo\ndescription: demo\n---\nUse demo.\n");
+  fs.writeFileSync(path.join(dir, "agents", "main", "sessions", "session.jsonl"), "{\"type\":\"message\"}\n");
+  fs.writeFileSync(path.join(dir, "identity", "device.json"), JSON.stringify({ deviceId: "demo-device" }, null, 2));
+}
+
+describe("run-openclaw-e2e-validation.sh", () => {
+  it("produces a local artifact and sanitized validation report", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "harnesshub-openclaw-e2e-"));
+    const sourceDir = path.join(tmpDir, "source");
+    const runDir = path.join(tmpDir, "run");
+    const reportJson = path.join(tmpDir, "openclaw-e2e-validation.json");
+    const reportMd = path.join(tmpDir, "openclaw-e2e-validation.md");
+
+    createOpenClawFixture(sourceDir);
+
+    const result = spawnSync("./scripts/run-openclaw-e2e-validation.sh", [], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        HARNESSHUB_OPENCLAW_E2E_SOURCE_DIR: sourceDir,
+        HARNESSHUB_OPENCLAW_E2E_RUN_DIR: runDir,
+        HARNESSHUB_OPENCLAW_E2E_REPORT_JSON: reportJson,
+        HARNESSHUB_OPENCLAW_E2E_REPORT_MD: reportMd,
+      },
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("OpenClaw e2e validation complete.");
+    expect(fs.existsSync(path.join(runDir, "openclaw-template.harness"))).toBe(true);
+
+    const report = JSON.parse(fs.readFileSync(reportJson, "utf8"));
+    expect(report.sourceDir).toBe(sourceDir);
+    expect(report.export.success).toBe(true);
+    expect(report.manifest.image.adapter).toBe("openclaw");
+    expect(report.verify.valid).toBe(true);
+
+    const markdown = fs.readFileSync(reportMd, "utf8");
+    expect(markdown).toContain("Artifact path:");
+    expect(markdown).toContain("Verify valid: `true`");
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
Closes #39

Run an end-to-end OpenClaw packaging validation against a real local instance and produce an actual `.harness` artifact that can be inspected as proof that the current packaging flow works in practice.

Implementation notes:
Latest retained local artifact:

- `.artifacts/openclaw-e2e/20260312T063701Z/openclaw-template.harness`

Validation:
- `./scripts/run-openclaw-e2e-validation.sh`
- `npm test`
- `./scripts/run-agent-preflight.sh`
- `./scripts/run-openclaw-e2e-validation.sh`
- `npm test`