### PR TITLE
[codex] Validate manifest contract at package boundaries

### DIFF
--- a/.codex/pm/issue-state/40-validate-manifest-contract-explicitly-during-export-import-and-verify.md
+++ b/.codex/pm/issue-state/40-validate-manifest-contract-explicitly-during-export-import-and-verify.md
@@ -1,0 +1,32 @@
+---
+type: issue_state
+issue: 40
+task: .codex/pm/tasks/product-direction/validate-manifest-contract-explicitly-during-export-import-and-verify.md
+title: Validate manifest contract explicitly during export, import, and verify
+status: done
+---
+
+## Summary
+
+Make the harness image manifest contract explicitly validated during export, import, and verify so malformed images fail early with clear errors.
+
+The manifest structure is now more explicit, but the current implementation still relies heavily on structural assumptions at call sites. Before broadening adapter support, the contract should be enforced directly so packaging behavior is predictable and errors are easier to diagnose.
+
+## Validated Facts
+
+- malformed or incomplete manifest data fails with explicit contract errors
+- export, import, and verify each enforce the manifest contract at their boundary
+- the implementation remains compatible with current MVP scope and improves confidence in future adapter expansion
+
+## Open Questions
+
+-
+
+## Next Steps
+
+- reuse the shared manifest validator for any later adapter-specific manifest extensions
+- expand the contract only when new image semantics become explicit product scope
+
+## Artifacts
+
+-

--- a/.codex/pm/tasks/product-direction/validate-manifest-contract-explicitly-during-export-import-and-verify.md
+++ b/.codex/pm/tasks/product-direction/validate-manifest-contract-explicitly-during-export-import-and-verify.md
@@ -1,0 +1,41 @@
+---
+type: task
+epic: product-direction
+slug: validate-manifest-contract-explicitly-during-export-import-and-verify
+title: Validate manifest contract explicitly during export, import, and verify
+status: done
+task_type: implementation
+labels: feature,test
+issue: 40
+state_path: .codex/pm/issue-state/40-validate-manifest-contract-explicitly-during-export-import-and-verify.md
+---
+
+## Context
+
+Make the harness image manifest contract explicitly validated during export, import, and verify so malformed images fail early with clear errors.
+
+The manifest structure is now more explicit, but the current implementation still relies heavily on structural assumptions at call sites. Before broadening adapter support, the contract should be enforced directly so packaging behavior is predictable and errors are easier to diagnose.
+
+## Deliverable
+
+Make the harness image manifest contract explicitly validated during export, import, and verify so malformed images fail early with clear errors.
+
+## Scope
+
+- validate required manifest structure and key semantic fields during export, import, and verify
+- improve failure messages when a `.harness` image does not satisfy the expected contract
+- keep the work aligned with the current OpenClaw-oriented MVP rather than adding a second runtime family
+
+## Acceptance Criteria
+
+- malformed or incomplete manifest data fails with explicit contract errors
+- export, import, and verify each enforce the manifest contract at their boundary
+- the implementation remains compatible with current MVP scope and improves confidence in future adapter expansion
+
+## Validation
+
+- `npm run build`
+- `npm test`
+- `./scripts/run-agent-preflight.sh`
+
+## Implementation Notes

--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -1,0 +1,177 @@
+import { SCHEMA_VERSION } from "./types.js";
+
+const VALID_PACK_TYPES = new Set(["template", "instance"]);
+const VALID_RISK_LEVELS = new Set(["safe-share", "internal-only", "trusted-migration-only"]);
+const VALID_HARNESS_INTENTS = new Set(["agent-runtime-environment"]);
+
+export function validateManifestContract(manifest: unknown): string[] {
+  const errors: string[] = [];
+
+  if (!isRecord(manifest)) {
+    return ["manifest must be an object"];
+  }
+
+  requireExactString(manifest, "schemaVersion", errors);
+  if (typeof manifest.schemaVersion === "string" && manifest.schemaVersion !== SCHEMA_VERSION) {
+    errors.push(`schemaVersion must be ${SCHEMA_VERSION}`);
+  }
+
+  requireEnumString(manifest, "packType", VALID_PACK_TYPES, errors);
+  requireExactString(manifest, "packId", errors);
+  requireExactString(manifest, "createdAt", errors);
+
+  validateImageMetadata(manifest.image, errors);
+  validateLineage(manifest.lineage, errors);
+  validateBindings(manifest.bindings, errors);
+  validateHarnessMetadata(manifest.harness, errors);
+  validateSource(manifest.source, errors);
+  validateStringArray(manifest.includedPaths, "includedPaths", errors);
+  validateWorkspaces(manifest.workspaces, errors);
+  validateSensitiveFlags(manifest.sensitiveFlags, errors);
+  requireEnumString(manifest, "riskLevel", VALID_RISK_LEVELS, errors);
+
+  return errors;
+}
+
+export function assertValidManifest(manifest: unknown) {
+  const errors = validateManifestContract(manifest);
+  if (errors.length > 0) {
+    throw new Error(`Manifest contract validation failed: ${errors.join("; ")}`);
+  }
+}
+
+function validateImageMetadata(value: unknown, errors: string[]) {
+  if (!isRecord(value)) {
+    errors.push("image must be an object");
+    return;
+  }
+  requireExactString(value, "imageId", errors, "image.imageId");
+  requireExactString(value, "adapter", errors, "image.adapter");
+}
+
+function validateLineage(value: unknown, errors: string[]) {
+  if (!isRecord(value)) {
+    errors.push("lineage must be an object");
+    return;
+  }
+  if (!(value.parentImage === null || (isRecord(value.parentImage) && isNonEmptyString(value.parentImage.imageId)))) {
+    errors.push("lineage.parentImage must be null or an object with imageId");
+  }
+  validateStringArray(value.layerOrder, "lineage.layerOrder", errors);
+}
+
+function validateBindings(value: unknown, errors: string[]) {
+  if (!isRecord(value)) {
+    errors.push("bindings must be an object");
+    return;
+  }
+  if (!Array.isArray(value.workspaces)) {
+    errors.push("bindings.workspaces must be an array");
+    return;
+  }
+  value.workspaces.forEach((workspace, index) => validateWorkspaceBindingRule(workspace, index, errors));
+}
+
+function validateWorkspaceBindingRule(value: unknown, index: number, errors: string[]) {
+  if (!isRecord(value)) {
+    errors.push(`bindings.workspaces[${index}] must be an object`);
+    return;
+  }
+  requireExactString(value, "agentId", errors, `bindings.workspaces[${index}].agentId`);
+  requireExactString(value, "logicalPath", errors, `bindings.workspaces[${index}].logicalPath`);
+  requireExactString(value, "targetRelativePath", errors, `bindings.workspaces[${index}].targetRelativePath`);
+  validateStringArray(value.configTargets, `bindings.workspaces[${index}].configTargets`, errors);
+  if (typeof value.required !== "boolean") {
+    errors.push(`bindings.workspaces[${index}].required must be a boolean`);
+  }
+}
+
+function validateHarnessMetadata(value: unknown, errors: string[]) {
+  if (!isRecord(value)) {
+    errors.push("harness must be an object");
+    return;
+  }
+  requireEnumString(value, "intent", VALID_HARNESS_INTENTS, errors, "harness.intent");
+  requireExactString(value, "targetProduct", errors, "harness.targetProduct");
+  validateStringArray(value.components, "harness.components", errors);
+}
+
+function validateSource(value: unknown, errors: string[]) {
+  if (!isRecord(value)) {
+    errors.push("source must be an object");
+    return;
+  }
+  requireExactString(value, "product", errors, "source.product");
+  requireExactString(value, "version", errors, "source.version");
+  if (typeof value.configPath !== "string") {
+    errors.push("source.configPath must be a string");
+  }
+}
+
+function validateWorkspaces(value: unknown, errors: string[]) {
+  if (!Array.isArray(value)) {
+    errors.push("workspaces must be an array");
+    return;
+  }
+  value.forEach((workspace, index) => {
+    if (!isRecord(workspace)) {
+      errors.push(`workspaces[${index}] must be an object`);
+      return;
+    }
+    requireExactString(workspace, "agentId", errors, `workspaces[${index}].agentId`);
+    requireExactString(workspace, "logicalPath", errors, `workspaces[${index}].logicalPath`);
+    requireExactString(workspace, "packPath", errors, `workspaces[${index}].packPath`);
+    if (typeof workspace.isDefault !== "boolean") {
+      errors.push(`workspaces[${index}].isDefault must be a boolean`);
+    }
+  });
+}
+
+function validateSensitiveFlags(value: unknown, errors: string[]) {
+  if (!isRecord(value)) {
+    errors.push("sensitiveFlags must be an object");
+    return;
+  }
+  const keys = [
+    "hasCredentials",
+    "hasApiKeys",
+    "hasOAuthTokens",
+    "hasAuthProfiles",
+    "hasWhatsAppCreds",
+    "hasCopilotToken",
+    "hasSessions",
+    "hasMemoryDb",
+    "hasEnvFile",
+  ];
+  for (const key of keys) {
+    if (typeof value[key] !== "boolean") {
+      errors.push(`sensitiveFlags.${key} must be a boolean`);
+    }
+  }
+}
+
+function validateStringArray(value: unknown, label: string, errors: string[]) {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+    errors.push(`${label} must be an array of strings`);
+  }
+}
+
+function requireExactString(value: Record<string, unknown>, key: string, errors: string[], label = key) {
+  if (!isNonEmptyString(value[key])) {
+    errors.push(`${label} must be a non-empty string`);
+  }
+}
+
+function requireEnumString(value: Record<string, unknown>, key: string, allowed: Set<string>, errors: string[], label = key) {
+  if (!isNonEmptyString(value[key]) || !allowed.has(String(value[key]))) {
+    errors.push(`${label} must be one of: ${[...allowed].join(", ")}`);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}

--- a/src/core/packer.ts
+++ b/src/core/packer.ts
@@ -18,6 +18,7 @@ import type {
 } from "./types.js";
 import { SCHEMA_VERSION } from "./types.js";
 import { openClawAdapter } from "./adapters/openclaw.js";
+import { assertValidManifest } from "./manifest.js";
 
 // Files/dirs to exclude from template packs (security-critical)
 const TEMPLATE_EXCLUDES = [
@@ -344,6 +345,7 @@ export async function exportPack(options: ExportOptions): Promise<ExportResult> 
     sensitiveFlags: inspectResult.sensitiveFlags,
     riskLevel: assessRisk(inspectResult.sensitiveFlags, packType),
   };
+  assertValidManifest(manifest);
 
   // Create staging directory
   const stagingDir = path.join(stateDir, ".harness-staging");
@@ -449,29 +451,8 @@ export async function importPack(options: ImportOptions): Promise<ImportResult> 
       throw new Error("Invalid HarnessHub package: manifest.json not found");
     }
 
-    const parsedManifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as Partial<Manifest>;
-    const packId = parsedManifest.packId ?? generatePackId();
-    const manifest: Manifest = {
-      ...parsedManifest,
-      packId,
-      image: parsedManifest.image ?? createImageMetadata(packId, parsedManifest.source?.product ?? openClawAdapter.id),
-      lineage: {
-        parentImage: parsedManifest.lineage?.parentImage ?? null,
-        layerOrder: Array.isArray(parsedManifest.lineage?.layerOrder) ? parsedManifest.lineage.layerOrder : [],
-      },
-      bindings: {
-        workspaces: Array.isArray(parsedManifest.bindings?.workspaces)
-          ? parsedManifest.bindings.workspaces
-          : createBindingSemantics(Array.isArray(parsedManifest.workspaces) ? parsedManifest.workspaces : []).workspaces,
-      },
-      harness: parsedManifest.harness ?? createHarnessMetadata(
-        Array.isArray(parsedManifest.includedPaths) ? parsedManifest.includedPaths : [],
-        parsedManifest.source?.configPath ? parsedManifest.source.configPath : null,
-        parsedManifest.source?.product ?? "openclaw"
-      ),
-      includedPaths: Array.isArray(parsedManifest.includedPaths) ? parsedManifest.includedPaths : [],
-      workspaces: Array.isArray(parsedManifest.workspaces) ? parsedManifest.workspaces : [],
-    } as Manifest;
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as Manifest;
+    assertValidManifest(manifest);
 
     const targetDir = options.targetPath
       ? path.resolve(options.targetPath)

--- a/src/core/verifier.ts
+++ b/src/core/verifier.ts
@@ -4,6 +4,7 @@ import JSON5 from "json5";
 import type { Manifest, VerifyResult, VerifyCheck } from "./types.js";
 import { SCHEMA_VERSION } from "./types.js";
 import { openClawAdapter } from "./adapters/openclaw.js";
+import { validateManifestContract } from "./manifest.js";
 
 const REQUIRED_WORKSPACE_FILES = ["AGENTS.md"];
 
@@ -131,6 +132,19 @@ export function verify(targetDir: string, manifest?: Manifest): VerifyResult {
 
   // Check 7: Manifest validation
   if (manifest) {
+    const manifestContractErrors = validateManifestContract(manifest);
+    checks.push({
+      name: "manifest_contract",
+      passed: manifestContractErrors.length === 0,
+      message: manifestContractErrors.length === 0
+        ? "Manifest contract is valid"
+        : manifestContractErrors.join("; "),
+    });
+    if (manifestContractErrors.length > 0) {
+      errors.push(...manifestContractErrors.map((error: string) => `Manifest contract error: ${error}`));
+      return { valid: false, checks, warnings, errors };
+    }
+
     const schemaMatch = manifest.schemaVersion === SCHEMA_VERSION;
     checks.push({
       name: "manifest_schema",

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import * as tar from "tar";
 import { inspect } from "../src/core/scanner.js";
 import { exportPack, importPack } from "../src/core/packer.js";
 import { verify } from "../src/core/verifier.js";
@@ -369,6 +370,51 @@ describe("export + import", () => {
     expect(fs.existsSync(path.join(targetDir, ".harness-manifest.json"))).toBe(true);
   });
 
+  it("rejects importing a pack with an invalid manifest contract", async () => {
+    const packFile = path.join(tmpDir, "invalid-manifest.harness");
+    const stagingDir = path.join(tmpDir, "invalid-pack");
+    fs.mkdirSync(path.join(stagingDir, "workspace"), { recursive: true });
+    fs.writeFileSync(path.join(stagingDir, "workspace", "AGENTS.md"), "# Agent\n");
+    fs.writeFileSync(path.join(stagingDir, "manifest.json"), JSON.stringify({
+      schemaVersion: "0.5.0",
+      packType: "template",
+      packId: "broken-pack",
+      createdAt: "2026-03-12T00:00:00.000Z",
+      lineage: { parentImage: null, layerOrder: [] },
+      bindings: { workspaces: [] },
+      harness: {
+        intent: "agent-runtime-environment",
+        targetProduct: "openclaw",
+        components: ["workspace", "config"],
+      },
+      source: {
+        product: "openclaw",
+        version: "unknown",
+        configPath: "openclaw.json",
+      },
+      includedPaths: ["workspace/AGENTS.md"],
+      workspaces: [],
+      sensitiveFlags: {
+        hasCredentials: false,
+        hasApiKeys: false,
+        hasOAuthTokens: false,
+        hasAuthProfiles: false,
+        hasWhatsAppCreds: false,
+        hasCopilotToken: false,
+        hasSessions: false,
+        hasMemoryDb: false,
+        hasEnvFile: false,
+      },
+      riskLevel: "safe-share",
+    }, null, 2));
+    await tar.create({ gzip: true, file: packFile, cwd: stagingDir }, ["manifest.json", "workspace"]);
+
+    await expect(importPack({
+      packFile,
+      targetPath: path.join(tmpDir, "broken-target"),
+    })).rejects.toThrow(/Manifest contract validation failed/);
+  });
+
   it("imports instance pack preserving agent directory structure", async () => {
     const instanceDir = createMockInstanceWithSensitiveData(path.join(tmpDir, "source"));
     const packFile = path.join(tmpDir, "instance.harness");
@@ -509,7 +555,7 @@ describe("verify", () => {
     expect(result.checks.some(c => c.name === "agents_present" && c.passed)).toBe(true);
   });
 
-  it("warns when manifest harness metadata is missing", () => {
+  it("fails when manifest contract metadata is missing", () => {
     const instanceDir = createMockInstance(path.join(tmpDir, "verify-harness"));
     const result = verify(instanceDir, {
       schemaVersion: "0.3.0",
@@ -537,9 +583,58 @@ describe("verify", () => {
       riskLevel: "safe-share",
     } as any);
 
-    expect(result.checks.some(c => c.name === "manifest_image" && !c.passed)).toBe(true);
-    expect(result.checks.some(c => c.name === "manifest_lineage" && !c.passed)).toBe(true);
-    expect(result.checks.some(c => c.name === "manifest_harness" && !c.passed)).toBe(true);
-    expect(result.warnings.some(w => w.includes("reusable agent runtime environment"))).toBe(true);
+    expect(result.valid).toBe(false);
+    expect(result.checks.some(c => c.name === "manifest_contract" && !c.passed)).toBe(true);
+    expect(result.errors.some((error) => error.includes("image must be an object"))).toBe(true);
+    expect(result.errors.some((error) => error.includes("harness must be an object"))).toBe(true);
+  });
+
+  it("fails verification when the manifest contract is invalid", () => {
+    const instanceDir = createMockInstance(path.join(tmpDir, "verify-invalid-manifest"));
+    const result = verify(instanceDir, {
+      schemaVersion: "0.5.0",
+      packType: "template",
+      packId: "broken-pack",
+      createdAt: "2026-03-12T00:00:00.000Z",
+      image: {
+        imageId: "broken-pack",
+        adapter: "",
+      },
+      lineage: {
+        parentImage: null,
+        layerOrder: [],
+      },
+      bindings: {
+        workspaces: [],
+      },
+      harness: {
+        intent: "agent-runtime-environment",
+        targetProduct: "openclaw",
+        components: ["workspace"],
+      },
+      source: {
+        product: "openclaw",
+        version: "unknown",
+        configPath: "openclaw.json",
+      },
+      includedPaths: [],
+      workspaces: [],
+      sensitiveFlags: {
+        hasCredentials: false,
+        hasApiKeys: false,
+        hasOAuthTokens: false,
+        hasAuthProfiles: false,
+        hasWhatsAppCreds: false,
+        hasCopilotToken: false,
+        hasSessions: false,
+        hasMemoryDb: false,
+        hasEnvFile: false,
+      },
+      riskLevel: "safe-share",
+    } as any);
+
+    expect(result.valid).toBe(false);
+    expect(result.checks.some((check) => check.name === "manifest_contract" && !check.passed)).toBe(true);
+    expect(result.errors.some((error) => error.includes("image.adapter"))).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #40

Make the harness image manifest contract explicitly validated during export, import, and verify so malformed images fail early with clear errors.

Validation:
- `npm run build`
- `npm test`
- `./scripts/run-agent-preflight.sh`
- `npm run build`
- `npm test`