### PR TITLE
[codex] Define explicit template vs instance image contract

### DIFF
--- a/.codex/pm/issue-state/47-define-explicit-template-vs-instance-image-contract.md
+++ b/.codex/pm/issue-state/47-define-explicit-template-vs-instance-image-contract.md
@@ -1,0 +1,32 @@
+---
+type: issue_state
+issue: 47
+task: .codex/pm/tasks/product-direction/define-explicit-template-vs-instance-image-contract.md
+title: Define explicit template vs instance image contract
+status: done
+---
+
+## Summary
+
+Turn the current template vs instance distinction into an explicit image contract instead of leaving it as a mostly exclusion-list-driven behavior.
+
+The real OpenClaw end-to-end artifact proved the packaging loop works, but it also showed that `template` still carries a mix of stateful components that are not yet governed by a strong semantic contract. Before broadening scope, HarnessHub should define exactly what a template image may and may not contain.
+
+## Validated Facts
+
+- `template` and `instance` are defined as explicit image contracts, not only operational modes
+- pack-type semantics are clear enough to explain why a real source may be recommended as `instance`
+- export and verify behavior can enforce the distinction consistently
+
+## Open Questions
+
+-
+
+## Next Steps
+
+- monitor whether template policy needs finer component classification once placement rules harden
+- treat the explicit pack-type contract as the baseline for the next verification-layer work
+
+## Artifacts
+
+-

--- a/.codex/pm/tasks/product-direction/define-explicit-template-vs-instance-image-contract.md
+++ b/.codex/pm/tasks/product-direction/define-explicit-template-vs-instance-image-contract.md
@@ -1,0 +1,41 @@
+---
+type: task
+epic: product-direction
+slug: define-explicit-template-vs-instance-image-contract
+title: Define explicit template vs instance image contract
+status: done
+task_type: implementation
+labels: feature,design
+issue: 47
+state_path: .codex/pm/issue-state/47-define-explicit-template-vs-instance-image-contract.md
+---
+
+## Context
+
+Turn the current template vs instance distinction into an explicit image contract instead of leaving it as a mostly exclusion-list-driven behavior.
+
+The real OpenClaw end-to-end artifact proved the packaging loop works, but it also showed that `template` still carries a mix of stateful components that are not yet governed by a strong semantic contract. Before broadening scope, HarnessHub should define exactly what a template image may and may not contain.
+
+## Deliverable
+
+Turn the current template vs instance distinction into an explicit image contract instead of leaving it as a mostly exclusion-list-driven behavior.
+
+## Scope
+
+- define allowed and forbidden component classes for `template` and `instance`
+- clarify how inspect recommendations, risk levels, and user intent interact with pack type selection
+- align export and verification behavior with the stronger pack-type contract
+
+## Acceptance Criteria
+
+- `template` and `instance` are defined as explicit image contracts, not only operational modes
+- pack-type semantics are clear enough to explain why a real source may be recommended as `instance`
+- export and verify behavior can enforce the distinction consistently
+
+## Validation
+
+- `npm run build`
+- `npm test`
+- `./scripts/run-agent-preflight.sh`
+
+## Implementation Notes

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -39,6 +39,7 @@ export const exportCommand = new Command("export")
           riskLevel: result.manifest.riskLevel,
           fileCount: result.fileCount,
           totalSize: result.totalSize,
+          warnings: result.warnings,
         }, null, 2));
       } else {
         console.log("");
@@ -50,6 +51,14 @@ export const exportCommand = new Command("export")
         console.log(`  Files:        ${result.fileCount}`);
         console.log(`  Size:         ${formatSize(result.totalSize)}`);
         console.log(`  Output:       ${result.outputFile}`);
+
+        if (result.warnings.length > 0) {
+          console.log("");
+          console.log("--- Warnings ---");
+          for (const warning of result.warnings) {
+            console.log(`  ! ${warning}`);
+          }
+        }
         console.log("");
         console.log("Export complete.");
         console.log("");

--- a/src/core/pack-contract.ts
+++ b/src/core/pack-contract.ts
@@ -1,0 +1,33 @@
+import type { HarnessComponent, PackType } from "./types.js";
+
+const TEMPLATE_FORBIDDEN_COMPONENTS = new Set<HarnessComponent>([
+  "agents",
+  "credentials",
+  "sessions",
+  "memory",
+  "logs",
+  "browser",
+]);
+
+const TEMPLATE_FORBIDDEN_TOP_LEVEL_DIRS = new Set([
+  "agents",
+  "credentials",
+  "memory",
+  "logs",
+  "browser",
+  "devices",
+  "identity",
+]);
+
+export function isForbiddenInPackType(relativePath: string, packType: PackType): boolean {
+  if (packType !== "template") return false;
+  const topLevel = relativePath.split("/")[0] ?? "";
+  return TEMPLATE_FORBIDDEN_TOP_LEVEL_DIRS.has(topLevel);
+}
+
+export function validatePackTypeComponents(packType: PackType, components: readonly HarnessComponent[]): string[] {
+  if (packType !== "template") return [];
+  return components
+    .filter((component) => TEMPLATE_FORBIDDEN_COMPONENTS.has(component))
+    .map((component) => `template packs must not include ${component}`);
+}

--- a/src/core/packer.ts
+++ b/src/core/packer.ts
@@ -19,6 +19,7 @@ import type {
 import { SCHEMA_VERSION } from "./types.js";
 import { openClawAdapter } from "./adapters/openclaw.js";
 import { assertValidManifest } from "./manifest.js";
+import { isForbiddenInPackType, validatePackTypeComponents } from "./pack-contract.js";
 
 // Files/dirs to exclude from template packs (security-critical)
 const TEMPLATE_EXCLUDES = [
@@ -159,6 +160,7 @@ function collectFiles(
         continue;
       }
 
+      if (isForbiddenInPackType(relPath.split(path.sep).join("/"), packType)) continue;
       if (shouldExclude(relPath, packType)) continue;
 
       if (entry.isFile()) {
@@ -269,6 +271,7 @@ interface ExportResult {
   manifest: Manifest;
   fileCount: number;
   totalSize: number;
+  warnings: string[];
 }
 
 export async function exportPack(options: ExportOptions): Promise<ExportResult> {
@@ -345,6 +348,16 @@ export async function exportPack(options: ExportOptions): Promise<ExportResult> 
     sensitiveFlags: inspectResult.sensitiveFlags,
     riskLevel: assessRisk(inspectResult.sensitiveFlags, packType),
   };
+  const warnings: string[] = [];
+  if (inspectResult.recommendedPackType !== packType) {
+    warnings.push(
+      `Inspect recommended ${inspectResult.recommendedPackType}; exporting ${packType} applies the explicit ${packType} contract instead.`
+    );
+  }
+  const packTypeContractErrors = validatePackTypeComponents(packType, manifest.harness.components);
+  if (packTypeContractErrors.length > 0) {
+    throw new Error(`Pack type contract violation: ${packTypeContractErrors.join("; ")}`);
+  }
   assertValidManifest(manifest);
 
   // Create staging directory
@@ -413,7 +426,7 @@ export async function exportPack(options: ExportOptions): Promise<ExportResult> 
       fs.readdirSync(stagingDir)
     );
 
-    return { outputFile, manifest, fileCount: filesToExport.length, totalSize };
+    return { outputFile, manifest, fileCount: filesToExport.length, totalSize, warnings };
   } finally {
     fs.rmSync(stagingDir, { recursive: true, force: true });
   }

--- a/src/core/verifier.ts
+++ b/src/core/verifier.ts
@@ -5,6 +5,7 @@ import type { Manifest, VerifyResult, VerifyCheck } from "./types.js";
 import { SCHEMA_VERSION } from "./types.js";
 import { openClawAdapter } from "./adapters/openclaw.js";
 import { validateManifestContract } from "./manifest.js";
+import { validatePackTypeComponents } from "./pack-contract.js";
 
 const REQUIRED_WORKSPACE_FILES = ["AGENTS.md"];
 
@@ -162,6 +163,21 @@ export function verify(targetDir: string, manifest?: Manifest): VerifyResult {
       passed: ["template", "instance"].includes(manifest.packType),
       message: `Pack type: ${manifest.packType}`,
     });
+
+    const packTypeContractErrors = validatePackTypeComponents(
+      manifest.packType,
+      manifest.harness.components
+    );
+    checks.push({
+      name: "pack_type_contract",
+      passed: packTypeContractErrors.length === 0,
+      message: packTypeContractErrors.length === 0
+        ? `${manifest.packType} contract satisfied`
+        : packTypeContractErrors.join("; "),
+    });
+    if (packTypeContractErrors.length > 0) {
+      errors.push(...packTypeContractErrors.map((error) => `Pack type contract error: ${error}`));
+    }
 
     const hasImageMetadata =
       typeof manifest.image?.imageId === "string" &&

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -322,6 +322,30 @@ describe("export + import", () => {
     expect(paths.some(p => p.includes(path.join("cron", "runs")))).toBe(false);
   });
 
+  it("template pack excludes runtime-state directories by contract", async () => {
+    const instanceDir = createMockInstanceWithSensitiveData(path.join(tmpDir, "contract"));
+    fs.mkdirSync(path.join(instanceDir, "browser", "profile"), { recursive: true });
+    fs.writeFileSync(path.join(instanceDir, "browser", "profile", "state.json"), "{}");
+    fs.mkdirSync(path.join(instanceDir, "identity"), { recursive: true });
+    fs.writeFileSync(path.join(instanceDir, "identity", "device.json"), "{}");
+    const outputFile = path.join(tmpDir, "contract-template.harness");
+
+    const result = await exportPack({
+      sourcePath: instanceDir,
+      outputPath: outputFile,
+      packType: "template",
+    });
+
+    expect(result.manifest.harness.components).not.toContain("agents");
+    expect(result.manifest.harness.components).not.toContain("sessions");
+    expect(result.manifest.harness.components).not.toContain("credentials");
+    expect(result.manifest.harness.components).not.toContain("browser");
+    expect(result.manifest.includedPaths.some((p) => p.startsWith("agents/"))).toBe(false);
+    expect(result.manifest.includedPaths.some((p) => p.startsWith("credentials/"))).toBe(false);
+    expect(result.manifest.includedPaths.some((p) => p.startsWith("memory/"))).toBe(false);
+    expect(result.warnings.some((warning) => warning.includes("Inspect recommended instance"))).toBe(true);
+  });
+
   it("instance pack preserves agent directory structure", async () => {
     const instanceDir = createMockInstanceWithSensitiveData(path.join(tmpDir, "full"));
     const outputFile = path.join(tmpDir, "instance.harness");
@@ -636,5 +660,54 @@ describe("verify", () => {
     expect(result.valid).toBe(false);
     expect(result.checks.some((check) => check.name === "manifest_contract" && !check.passed)).toBe(true);
     expect(result.errors.some((error) => error.includes("image.adapter"))).toBe(true);
+  });
+
+  it("fails verification when a template manifest declares forbidden runtime-state components", () => {
+    const instanceDir = createMockInstance(path.join(tmpDir, "verify-pack-contract"));
+    const result = verify(instanceDir, {
+      schemaVersion: "0.5.0",
+      packType: "template",
+      packId: "template-with-agents",
+      createdAt: "2026-03-12T00:00:00.000Z",
+      image: {
+        imageId: "template-with-agents",
+        adapter: "openclaw",
+      },
+      lineage: {
+        parentImage: null,
+        layerOrder: [],
+      },
+      bindings: {
+        workspaces: [],
+      },
+      harness: {
+        intent: "agent-runtime-environment",
+        targetProduct: "openclaw",
+        components: ["workspace", "config", "agents"],
+      },
+      source: {
+        product: "openclaw",
+        version: "unknown",
+        configPath: "openclaw.json",
+      },
+      includedPaths: ["openclaw.json", "workspace/AGENTS.md"],
+      workspaces: [],
+      sensitiveFlags: {
+        hasCredentials: false,
+        hasApiKeys: false,
+        hasOAuthTokens: false,
+        hasAuthProfiles: false,
+        hasWhatsAppCreds: false,
+        hasCopilotToken: false,
+        hasSessions: false,
+        hasMemoryDb: false,
+        hasEnvFile: false,
+      },
+      riskLevel: "safe-share",
+    } as any);
+
+    expect(result.valid).toBe(false);
+    expect(result.checks.some((check) => check.name === "pack_type_contract" && !check.passed)).toBe(true);
+    expect(result.errors.some((error) => error.includes("template packs must not include agents"))).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #47

Turn the current template vs instance distinction into an explicit image contract instead of leaving it as a mostly exclusion-list-driven behavior.

Validation:
- `npm run build`
- `npm test`
- `./scripts/run-agent-preflight.sh`
- `npm run build`
- `npm test`