### PR TITLE
[codex] Separate structural restore from runtime-ready verification

### DIFF
--- a/.codex/pm/issue-state/45-separate-structural-restore-from-runtime-ready-verification.md
+++ b/.codex/pm/issue-state/45-separate-structural-restore-from-runtime-ready-verification.md
@@ -1,0 +1,32 @@
+---
+type: issue_state
+issue: 45
+task: .codex/pm/tasks/product-direction/separate-structural-restore-from-runtime-ready-verification.md
+title: Separate structural restore from runtime-ready verification
+status: done
+---
+
+## Summary
+
+Split verification semantics so HarnessHub can distinguish between a structurally restored import and a runtime-ready environment.
+
+The real OpenClaw artifact now passes verify while still surfacing warnings that imply the imported result may not be fully runtime-ready. That makes the current `valid` signal too coarse. HarnessHub should make its verification contract more explicit.
+
+## Validated Facts
+
+- verify output can distinguish structural success from runtime readiness
+- current warnings that imply incomplete runtime readiness are reflected in the verification model
+- the new model improves product clarity without requiring a second runtime adapter yet
+
+## Open Questions
+
+-
+
+## Next Steps
+
+- reuse runtime-readiness semantics in future validation records and CLI explanations
+- keep refining which warnings should affect runtime readiness as the image contract tightens
+
+## Artifacts
+
+-

--- a/.codex/pm/tasks/product-direction/separate-structural-restore-from-runtime-ready-verification.md
+++ b/.codex/pm/tasks/product-direction/separate-structural-restore-from-runtime-ready-verification.md
@@ -1,0 +1,41 @@
+---
+type: task
+epic: product-direction
+slug: separate-structural-restore-from-runtime-ready-verification
+title: Separate structural restore from runtime-ready verification
+status: done
+task_type: implementation
+labels: feature,design
+issue: 45
+state_path: .codex/pm/issue-state/45-separate-structural-restore-from-runtime-ready-verification.md
+---
+
+## Context
+
+Split verification semantics so HarnessHub can distinguish between a structurally restored import and a runtime-ready environment.
+
+The real OpenClaw artifact now passes verify while still surfacing warnings that imply the imported result may not be fully runtime-ready. That makes the current `valid` signal too coarse. HarnessHub should make its verification contract more explicit.
+
+## Deliverable
+
+Split verification semantics so HarnessHub can distinguish between a structurally restored import and a runtime-ready environment.
+
+## Scope
+
+- define at least two verification levels: structural restore and runtime readiness
+- update verify reporting so users can tell whether an image merely restored correctly or is actually ready for runtime use
+- keep the initial implementation aligned with the current OpenClaw-oriented MVP
+
+## Acceptance Criteria
+
+- verify output can distinguish structural success from runtime readiness
+- current warnings that imply incomplete runtime readiness are reflected in the verification model
+- the new model improves product clarity without requiring a second runtime adapter yet
+
+## Validation
+
+- `npm run build`
+- `npm test`
+- `./scripts/run-agent-preflight.sh`
+
+## Implementation Notes

--- a/scripts/run-openclaw-e2e-validation.sh
+++ b/scripts/run-openclaw-e2e-validation.sh
@@ -91,7 +91,9 @@ const summary = {
   },
   verify: {
     valid: verify.valid,
+    runtimeReady: verify.runtimeReady,
     checkNames: (verify.checks ?? []).map((check) => check.name),
+    runtimeReadinessIssues: (verify.runtimeReadinessIssues ?? []).map(sanitizeText),
     warnings: (verify.warnings ?? []).map(sanitizeText),
     errors: (verify.errors ?? []).map(sanitizeText),
   },
@@ -147,6 +149,7 @@ const md = [
   `- Imported target: \`${summary.import.targetDir}\``,
   `- Imported file count: \`${summary.import.fileCount}\``,
   `- Verify valid: \`${summary.verify.valid}\``,
+  `- Runtime ready: \`${summary.verify.runtimeReady}\``,
   `- Verify checks: \`${summary.verify.checkNames.join(", ")}\``,
   "",
   "## Warnings",

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -132,6 +132,8 @@ export interface InstanceStructure {
 
 export interface VerifyResult {
   valid: boolean;
+  runtimeReady: boolean;
+  runtimeReadinessIssues: string[];
   checks: VerifyCheck[];
   warnings: string[];
   errors: string[];

--- a/src/core/verifier.ts
+++ b/src/core/verifier.ts
@@ -13,6 +13,7 @@ export function verify(targetDir: string, manifest?: Manifest): VerifyResult {
   const checks: VerifyCheck[] = [];
   const warnings: string[] = [];
   const errors: string[] = [];
+  const runtimeReadinessIssues: string[] = [];
   const manifestWorkspaces = manifest?.workspaces ?? [];
   const manifestBindingRules = manifest?.bindings?.workspaces ?? [];
 
@@ -28,7 +29,8 @@ export function verify(targetDir: string, manifest?: Manifest): VerifyResult {
 
   if (!dirExists) {
     errors.push("Target directory does not exist");
-    return { valid: false, checks, warnings, errors };
+    runtimeReadinessIssues.push("Target directory does not exist");
+    return { valid: false, runtimeReady: false, runtimeReadinessIssues, checks, warnings, errors };
   }
 
   // Check 2: Config file exists
@@ -43,6 +45,7 @@ export function verify(targetDir: string, manifest?: Manifest): VerifyResult {
   });
   if (!hasConfig) {
     warnings.push("No config file found - instance may need manual configuration");
+    runtimeReadinessIssues.push("No OpenClaw config file found");
   }
 
   // Check 3: Workspace directory exists
@@ -81,6 +84,7 @@ export function verify(targetDir: string, manifest?: Manifest): VerifyResult {
       });
       if (!exists) {
         warnings.push(`Workspace file missing: ${file}`);
+        runtimeReadinessIssues.push(`Workspace file missing: ${file}`);
       }
     }
   }
@@ -94,6 +98,7 @@ export function verify(targetDir: string, manifest?: Manifest): VerifyResult {
       configValid = true;
     } catch {
       warnings.push("Config file may not be valid JSON/JSON5");
+      runtimeReadinessIssues.push("Config file appears invalid");
     }
     checks.push({
       name: "config_valid",
@@ -126,6 +131,7 @@ export function verify(targetDir: string, manifest?: Manifest): VerifyResult {
         const hasAgentDir = fs.existsSync(agentDir);
         if (!hasAgentDir) {
           warnings.push(`Agent "${agentId}" missing agent/ subdirectory`);
+          runtimeReadinessIssues.push(`Agent "${agentId}" missing agent/ subdirectory`);
         }
       }
     } catch { /* ignore */ }
@@ -143,7 +149,8 @@ export function verify(targetDir: string, manifest?: Manifest): VerifyResult {
     });
     if (manifestContractErrors.length > 0) {
       errors.push(...manifestContractErrors.map((error: string) => `Manifest contract error: ${error}`));
-      return { valid: false, checks, warnings, errors };
+      runtimeReadinessIssues.push(...manifestContractErrors.map((error: string) => `Manifest contract error: ${error}`));
+      return { valid: false, runtimeReady: false, runtimeReadinessIssues, checks, warnings, errors };
     }
 
     const schemaMatch = manifest.schemaVersion === SCHEMA_VERSION;
@@ -177,6 +184,7 @@ export function verify(targetDir: string, manifest?: Manifest): VerifyResult {
     });
     if (packTypeContractErrors.length > 0) {
       errors.push(...packTypeContractErrors.map((error) => `Pack type contract error: ${error}`));
+      runtimeReadinessIssues.push(...packTypeContractErrors.map((error) => `Pack type contract error: ${error}`));
     }
 
     const hasImageMetadata =
@@ -241,6 +249,7 @@ export function verify(targetDir: string, manifest?: Manifest): VerifyResult {
       });
       if (missingWorkspace) {
         warnings.push(`Missing imported workspace: ${missingWorkspace.logicalPath}`);
+        runtimeReadinessIssues.push(`Missing imported workspace: ${missingWorkspace.logicalPath}`);
       }
     }
 
@@ -253,6 +262,7 @@ export function verify(targetDir: string, manifest?: Manifest): VerifyResult {
           parsedConfig = JSON5.parse(fs.readFileSync(configPathForBindings, "utf-8"));
         } catch {
           warnings.push(`Could not parse config to validate binding semantics: ${path.basename(configPathForBindings)}`);
+          runtimeReadinessIssues.push(`Could not parse config to validate binding semantics: ${path.basename(configPathForBindings)}`);
         }
       }
 
@@ -288,6 +298,7 @@ export function verify(targetDir: string, manifest?: Manifest): VerifyResult {
           : bindingFailures.join("; "),
       });
       warnings.push(...bindingFailures);
+      runtimeReadinessIssues.push(...bindingFailures);
     }
 
     // Check that expected file count roughly matches
@@ -345,6 +356,7 @@ export function verify(targetDir: string, manifest?: Manifest): VerifyResult {
   const valid = errors.length === 0 && checks.every(
     c => c.passed || !["directory_exists", "workspace_exists"].includes(c.name)
   );
+  const runtimeReady = valid && runtimeReadinessIssues.length === 0;
 
-  return { valid, checks, warnings, errors };
+  return { valid, runtimeReady, runtimeReadinessIssues, checks, warnings, errors };
 }

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -151,7 +151,8 @@ export function printVerifyResult(result: Record<string, unknown>, format: Outpu
   console.log("");
   console.log("=== HarnessHub Verify ===");
   console.log("");
-  console.log(`  Valid: ${r.valid ? "YES" : "NO"}`);
+  console.log(`  Structural restore: ${r.valid ? "YES" : "NO"}`);
+  console.log(`  Runtime ready:      ${r.runtimeReady ? "YES" : "NO"}`);
   console.log("");
 
   if (r.checks.length > 0) {
@@ -167,6 +168,14 @@ export function printVerifyResult(result: Record<string, unknown>, format: Outpu
     console.log("--- Warnings ---");
     for (const w of r.warnings) {
       console.log(`  ! ${w}`);
+    }
+  }
+
+  if (r.runtimeReadinessIssues.length > 0) {
+    console.log("");
+    console.log("--- Runtime Readiness Issues ---");
+    for (const issue of r.runtimeReadinessIssues) {
+      console.log(`  ! ${issue}`);
     }
   }
 

--- a/test/cli-integration.test.ts
+++ b/test/cli-integration.test.ts
@@ -98,6 +98,7 @@ describe("harness CLI integration", () => {
     expect(verifyResult.status).toBe(0);
     const data = JSON.parse(verifyResult.stdout);
     expect(data.valid).toBe(true);
+    expect(data.runtimeReady).toBe(true);
     expect(data.checks.some((check: { name: string; passed: boolean }) => check.name === "manifest_schema" && check.passed)).toBe(true);
   });
 
@@ -116,6 +117,7 @@ describe("harness CLI integration", () => {
     expect(verifyResult.status).toBe(0);
     const data = JSON.parse(verifyResult.stdout);
     expect(data.valid).toBe(true);
+    expect(data.runtimeReady).toBe(true);
   });
 
   it("returns a JSON error when importing a missing pack file", () => {
@@ -130,6 +132,7 @@ describe("harness CLI integration", () => {
     expect(result.status).toBe(1);
     const data = JSON.parse(result.stdout);
     expect(data.valid).toBe(false);
+    expect(data.runtimeReady).toBe(false);
     expect(data.errors).toContain("Target directory does not exist");
   });
 });

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -515,6 +515,7 @@ describe("export + import", () => {
 
     const verifyResult = verify(targetDir, importResult.manifest);
     expect(verifyResult.valid).toBe(true);
+    expect(verifyResult.runtimeReady).toBe(true);
     expect(verifyResult.errors).toHaveLength(0);
     expect(verifyResult.checks.some(c => c.name === "manifest_image" && c.passed)).toBe(true);
     expect(verifyResult.checks.some(c => c.name === "manifest_lineage" && c.passed)).toBe(true);
@@ -540,6 +541,7 @@ describe("export + import", () => {
 
     const verifyResult = verify(targetDir, importResult.manifest);
     expect(verifyResult.valid).toBe(true);
+    expect(verifyResult.runtimeReady).toBe(true);
     expect(verifyResult.errors).toHaveLength(0);
     expect(verifyResult.checks.some(c => c.name === "manifest_image" && c.passed)).toBe(true);
     expect(verifyResult.checks.some(c => c.name === "binding_semantics" && c.passed)).toBe(true);
@@ -552,12 +554,14 @@ describe("verify", () => {
     const result = verify(instanceDir);
 
     expect(result.valid).toBe(true);
+    expect(result.runtimeReady).toBe(true);
     expect(result.errors).toHaveLength(0);
   });
 
   it("fails for non-existent directory", () => {
     const result = verify(path.join(tmpDir, "nonexistent"));
     expect(result.valid).toBe(false);
+    expect(result.runtimeReady).toBe(false);
     expect(result.errors.length).toBeGreaterThan(0);
   });
 
@@ -569,6 +573,7 @@ describe("verify", () => {
     fs.mkdirSync(wsDir);
 
     const result = verify(dir);
+    expect(result.runtimeReady).toBe(false);
     expect(result.warnings.some(w => w.includes("AGENTS.md"))).toBe(true);
   });
 
@@ -577,6 +582,7 @@ describe("verify", () => {
     const result = verify(instanceDir);
 
     expect(result.checks.some(c => c.name === "agents_present" && c.passed)).toBe(true);
+    expect(result.runtimeReady).toBe(true);
   });
 
   it("fails when manifest contract metadata is missing", () => {
@@ -608,6 +614,7 @@ describe("verify", () => {
     } as any);
 
     expect(result.valid).toBe(false);
+    expect(result.runtimeReady).toBe(false);
     expect(result.checks.some(c => c.name === "manifest_contract" && !c.passed)).toBe(true);
     expect(result.errors.some((error) => error.includes("image must be an object"))).toBe(true);
     expect(result.errors.some((error) => error.includes("harness must be an object"))).toBe(true);
@@ -707,6 +714,7 @@ describe("verify", () => {
     } as any);
 
     expect(result.valid).toBe(false);
+    expect(result.runtimeReady).toBe(false);
     expect(result.checks.some((check) => check.name === "pack_type_contract" && !check.passed)).toBe(true);
     expect(result.errors.some((error) => error.includes("template packs must not include agents"))).toBe(true);
   });


### PR DESCRIPTION
Closes #45

Split verification semantics so HarnessHub can distinguish between a structurally restored import and a runtime-ready environment.

Validation:
- `npm run build`
- `npm test`
- `./scripts/run-agent-preflight.sh`
- `npm run build`
- `npm test`