### PR TITLE
[codex] Codify rebinding surface and component placement

### DIFF
--- a/.codex/pm/issue-state/46-codify-rebinding-surface-and-component-placement-in-the-image-spec.md
+++ b/.codex/pm/issue-state/46-codify-rebinding-surface-and-component-placement-in-the-image-spec.md
@@ -1,0 +1,32 @@
+---
+type: issue_state
+issue: 46
+task: .codex/pm/tasks/product-direction/codify-rebinding-surface-and-component-placement-in-the-image-spec.md
+title: Codify rebinding surface and component placement in the image spec
+status: done
+---
+
+## Summary
+
+Promote rebinding rules and component placement from implementation detail to explicit harness image specification.
+
+The current real artifact shows that workspace rebinding and top-level component placement already exist in practice, but the rules are still mostly inferred from code. Before future adapter expansion, HarnessHub should make these semantics first-class parts of the image spec.
+
+## Validated Facts
+
+- rebinding behavior is described as part of the image contract rather than only adapter logic
+- component placement rules are explicit enough to support future adapter work without archive-layout drift
+- manifest and verification semantics reflect the codified rules
+
+## Open Questions
+
+-
+
+## Next Steps
+
+- keep future adapter work aligned with the reserved roots and persisted manifest contract
+- extend the rebinding contract only when new mutable config surfaces become explicit product scope
+
+## Artifacts
+
+-

--- a/.codex/pm/tasks/product-direction/codify-rebinding-surface-and-component-placement-in-the-image-spec.md
+++ b/.codex/pm/tasks/product-direction/codify-rebinding-surface-and-component-placement-in-the-image-spec.md
@@ -1,0 +1,41 @@
+---
+type: task
+epic: product-direction
+slug: codify-rebinding-surface-and-component-placement-in-the-image-spec
+title: Codify rebinding surface and component placement in the image spec
+status: done
+task_type: implementation
+labels: feature,design
+issue: 46
+state_path: .codex/pm/issue-state/46-codify-rebinding-surface-and-component-placement-in-the-image-spec.md
+---
+
+## Context
+
+Promote rebinding rules and component placement from implementation detail to explicit harness image specification.
+
+The current real artifact shows that workspace rebinding and top-level component placement already exist in practice, but the rules are still mostly inferred from code. Before future adapter expansion, HarnessHub should make these semantics first-class parts of the image spec.
+
+## Deliverable
+
+Promote rebinding rules and component placement from implementation detail to explicit harness image specification.
+
+## Scope
+
+- define which fields and paths are allowed to change during import-time rebinding
+- define which top-level component locations are reserved by the image spec and which are adapter-specific
+- align manifest language and verification behavior with the codified rebinding and placement rules
+
+## Acceptance Criteria
+
+- rebinding behavior is described as part of the image contract rather than only adapter logic
+- component placement rules are explicit enough to support future adapter work without archive-layout drift
+- manifest and verification semantics reflect the codified rules
+
+## Validation
+
+- `npm run build`
+- `npm test`
+- `./scripts/run-agent-preflight.sh`
+
+## Implementation Notes

--- a/src/core/adapters/openclaw.ts
+++ b/src/core/adapters/openclaw.ts
@@ -12,6 +12,7 @@ import type { HarnessAdapter } from "./types.js";
 function rebindImportedConfig(targetDir: string, manifest: Manifest, warnings: string[]) {
   const configPath = findConfigFile(targetDir);
   const workspaceBindings = manifest.bindings?.workspaces ?? [];
+  const mutableTargets = new Set(manifest.rebinding?.mutableConfigTargets ?? []);
   if (!configPath || workspaceBindings.length === 0) return;
 
   let parsed: any;
@@ -40,7 +41,7 @@ function rebindImportedConfig(targetDir: string, manifest: Manifest, warnings: s
     const targetWorkspacePath = `${targetDir}/${workspace.targetRelativePath}`;
     const isDefault = workspace.targetRelativePath === "workspace";
 
-    if (isDefault && parsed.agents.defaults.workspace !== targetWorkspacePath) {
+    if (isDefault && mutableTargets.has("agents.defaults.workspace") && parsed.agents.defaults.workspace !== targetWorkspacePath) {
       parsed.agents.defaults.workspace = targetWorkspacePath;
       changed = true;
     }
@@ -49,7 +50,7 @@ function rebindImportedConfig(targetDir: string, manifest: Manifest, warnings: s
       const id = typeof entry?.id === "string" ? entry.id.trim().toLowerCase() : "";
       return id === workspace.agentId;
     });
-    if (agentEntry && agentEntry.workspace !== targetWorkspacePath) {
+    if (agentEntry && mutableTargets.has(`agents.list[${workspace.agentId}].workspace`) && agentEntry.workspace !== targetWorkspacePath) {
       agentEntry.workspace = targetWorkspacePath;
       changed = true;
     }

--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -22,6 +22,8 @@ export function validateManifestContract(manifest: unknown): string[] {
 
   validateImageMetadata(manifest.image, errors);
   validateLineage(manifest.lineage, errors);
+  validatePlacement(manifest.placement, errors);
+  validateRebinding(manifest.rebinding, errors);
   validateBindings(manifest.bindings, errors);
   validateHarnessMetadata(manifest.harness, errors);
   validateSource(manifest.source, errors);
@@ -70,6 +72,35 @@ function validateBindings(value: unknown, errors: string[]) {
     return;
   }
   value.workspaces.forEach((workspace, index) => validateWorkspaceBindingRule(workspace, index, errors));
+}
+
+function validatePlacement(value: unknown, errors: string[]) {
+  if (!isRecord(value)) {
+    errors.push("placement must be an object");
+    return;
+  }
+  validateStringArray(value.reservedRoots, "placement.reservedRoots", errors);
+  if (!isRecord(value.componentRoots)) {
+    errors.push("placement.componentRoots must be an object");
+  } else {
+    requireExactString(value.componentRoots, "config", errors, "placement.componentRoots.config");
+    requireExactString(value.componentRoots, "workspace", errors, "placement.componentRoots.workspace");
+    requireExactString(value.componentRoots, "workspaces", errors, "placement.componentRoots.workspaces");
+    requireExactString(value.componentRoots, "reports", errors, "placement.componentRoots.reports");
+    requireExactString(value.componentRoots, "state", errors, "placement.componentRoots.state");
+  }
+  requireExactString(value, "persistedManifestPath", errors, "placement.persistedManifestPath");
+}
+
+function validateRebinding(value: unknown, errors: string[]) {
+  if (!isRecord(value)) {
+    errors.push("rebinding must be an object");
+    return;
+  }
+  if (value.workspaceTargetMode !== "absolute-path") {
+    errors.push("rebinding.workspaceTargetMode must be absolute-path");
+  }
+  validateStringArray(value.mutableConfigTargets, "rebinding.mutableConfigTargets", errors);
 }
 
 function validateWorkspaceBindingRule(value: unknown, index: number, errors: string[]) {

--- a/src/core/packer.ts
+++ b/src/core/packer.ts
@@ -11,6 +11,8 @@ import type {
   HarnessImageMetadata,
   Manifest,
   PackType,
+  PlacementContract,
+  RebindingContract,
   RiskLevel,
   SensitiveFlags,
   WorkspaceBinding,
@@ -60,6 +62,16 @@ const ALWAYS_EXCLUDE = [
   "*.bak.*",
 ];
 
+const DEFAULT_COMPONENT_ROOTS = {
+  config: "config",
+  workspace: "workspace",
+  workspaces: "workspaces",
+  reports: "reports",
+  state: "state",
+} as const;
+
+const DEFAULT_PERSISTED_MANIFEST_PATH = ".harness-manifest.json";
+
 function generatePackId(): string {
   return crypto.randomUUID();
 }
@@ -91,6 +103,27 @@ function createBindingSemantics(workspaces: readonly WorkspaceBinding[]): Bindin
 
   return {
     workspaces: workspaceRules,
+  };
+}
+
+function createPlacementContract(): PlacementContract {
+  return {
+    reservedRoots: [
+      DEFAULT_COMPONENT_ROOTS.config,
+      DEFAULT_COMPONENT_ROOTS.workspace,
+      DEFAULT_COMPONENT_ROOTS.workspaces,
+      DEFAULT_COMPONENT_ROOTS.reports,
+      DEFAULT_COMPONENT_ROOTS.state,
+    ],
+    componentRoots: { ...DEFAULT_COMPONENT_ROOTS },
+    persistedManifestPath: DEFAULT_PERSISTED_MANIFEST_PATH,
+  };
+}
+
+function createRebindingContract(bindings: BindingSemantics): RebindingContract {
+  return {
+    workspaceTargetMode: "absolute-path",
+    mutableConfigTargets: [...new Set(bindings.workspaces.flatMap((binding) => binding.configTargets))],
   };
 }
 
@@ -177,6 +210,7 @@ function collectFiles(
 
 /** Determine pack subdirectory for a given source-relative path */
 function classifyPath(relPath: string): string {
+  const roots = DEFAULT_COMPONENT_ROOTS;
   const parts = relPath.split(path.sep);
 
   // workspace/ → workspace/
@@ -185,39 +219,39 @@ function classifyPath(relPath: string): string {
   // agents/<id>/agent/auth-profiles.json, models.json → state/ (instance) or skip
   // agents/<id>/sessions/ → state/
   // agents/ subtree preserves structure under state/
-  if (parts[0] === "agents") return path.join("state", relPath);
+  if (parts[0] === "agents") return path.join(roots.state, relPath);
 
   // credentials/ → state/
-  if (parts[0] === "credentials") return path.join("state", relPath);
+  if (parts[0] === "credentials") return path.join(roots.state, relPath);
 
   // cron/ → state/
-  if (parts[0] === "cron") return path.join("state", relPath);
+  if (parts[0] === "cron") return path.join(roots.state, relPath);
 
   // memory/ → state/
-  if (parts[0] === "memory") return path.join("state", relPath);
+  if (parts[0] === "memory") return path.join(roots.state, relPath);
 
   // hooks/, extensions/, skills/ → config/
   if (parts[0] === "hooks" || parts[0] === "extensions" || parts[0] === "skills") {
-    return path.join("config", relPath);
+    return path.join(roots.config, relPath);
   }
 
   // completions/ → config/
-  if (parts[0] === "completions") return path.join("config", relPath);
+  if (parts[0] === "completions") return path.join(roots.config, relPath);
 
   // Config files at root level
   const configExts = [".json", ".json5"];
   const ext = path.extname(relPath);
   if (parts.length === 1 && configExts.includes(ext)) {
-    return path.join("config", relPath);
+    return path.join(roots.config, relPath);
   }
 
   // .env at root → state/ (only in instance packs)
   if (parts.length === 1 && relPath === ".env") {
-    return path.join("state", relPath);
+    return path.join(roots.state, relPath);
   }
 
   // Everything else → state/
-  return path.join("state", relPath);
+  return path.join(roots.state, relPath);
 }
 
 function hasIncludedPath(includedPaths: readonly string[], pattern: RegExp): boolean {
@@ -329,6 +363,7 @@ export async function exportPack(options: ExportOptions): Promise<ExportResult> 
   }
 
   const packId = generatePackId();
+  const bindings = createBindingSemantics(workspaceBindings);
   const manifest: Manifest = {
     schemaVersion: SCHEMA_VERSION,
     packType,
@@ -336,7 +371,9 @@ export async function exportPack(options: ExportOptions): Promise<ExportResult> 
     createdAt: new Date().toISOString(),
     image: createImageMetadata(packId, openClawAdapter.id),
     lineage: createInitialLineage(),
-    bindings: createBindingSemantics(workspaceBindings),
+    placement: createPlacementContract(),
+    rebinding: createRebindingContract(bindings),
+    bindings,
     harness: createHarnessMetadata(includedPaths, configPath, inspectResult.product),
     source: {
       product: "openclaw",
@@ -375,10 +412,14 @@ export async function exportPack(options: ExportOptions): Promise<ExportResult> 
     );
 
     // Create base pack directories
-    const packDirs = ["config", "workspace", "reports"];
-    if (packType === "instance") packDirs.push("state");
+    const packDirs = [
+      manifest.placement.componentRoots.config,
+      manifest.placement.componentRoots.workspace,
+      manifest.placement.componentRoots.reports,
+    ];
+    if (packType === "instance") packDirs.push(manifest.placement.componentRoots.state);
     if (workspaceBindings.some((binding) => !binding.isDefault)) {
-      packDirs.push("workspaces");
+      packDirs.push(manifest.placement.componentRoots.workspaces);
     }
 
     for (const dir of packDirs) {
@@ -408,7 +449,7 @@ export async function exportPack(options: ExportOptions): Promise<ExportResult> 
       sensitiveFlags: manifest.sensitiveFlags,
     };
     fs.writeFileSync(
-      path.join(stagingDir, "reports", "export-report.json"),
+      path.join(stagingDir, manifest.placement.componentRoots.reports, "export-report.json"),
       JSON.stringify(report, null, 2)
     );
 
@@ -495,31 +536,31 @@ export async function importPack(options: ImportOptions): Promise<ImportResult> 
     fs.mkdirSync(targetDir, { recursive: true });
 
     // Restore workspace/ → workspace/
-    const wsSource = path.join(tempDir, "workspace");
+    const wsSource = path.join(tempDir, manifest.placement.componentRoots.workspace);
     if (fs.existsSync(wsSource)) {
-      copyDirRecursive(wsSource, path.join(targetDir, "workspace"));
+      copyDirRecursive(wsSource, path.join(targetDir, manifest.placement.componentRoots.workspace));
     }
 
-    const workspacesSource = path.join(tempDir, "workspaces");
+    const workspacesSource = path.join(tempDir, manifest.placement.componentRoots.workspaces);
     if (fs.existsSync(workspacesSource)) {
       restoreAgentWorkspaces(workspacesSource, targetDir);
     }
 
     // Restore config/ → root level (config files go to stateDir root)
-    const configSource = path.join(tempDir, "config");
+    const configSource = path.join(tempDir, manifest.placement.componentRoots.config);
     if (fs.existsSync(configSource)) {
       restoreConfigDir(configSource, targetDir);
     }
 
     // Restore state/ → preserving nested structure
-    const stateSource = path.join(tempDir, "state");
+    const stateSource = path.join(tempDir, manifest.placement.componentRoots.state);
     if (fs.existsSync(stateSource)) {
       restoreStateDir(stateSource, targetDir);
     }
 
     openClawAdapter.rebindImportedConfig(targetDir, manifest, warnings);
     fs.writeFileSync(
-      path.join(targetDir, ".harness-manifest.json"),
+      path.join(targetDir, manifest.placement.persistedManifestPath),
       `${JSON.stringify(manifest, null, 2)}\n`
     );
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -13,6 +13,8 @@ export interface Manifest {
   createdAt: string;
   image: HarnessImageMetadata;
   lineage: HarnessImageLineage;
+  placement: PlacementContract;
+  rebinding: RebindingContract;
   bindings: BindingSemantics;
   harness: HarnessMetadata;
   source: {
@@ -40,6 +42,23 @@ export interface HarnessImageReference {
 export interface HarnessImageLineage {
   parentImage: HarnessImageReference | null;
   layerOrder: string[];
+}
+
+export interface PlacementContract {
+  reservedRoots: string[];
+  componentRoots: {
+    config: string;
+    workspace: string;
+    workspaces: string;
+    reports: string;
+    state: string;
+  };
+  persistedManifestPath: string;
+}
+
+export interface RebindingContract {
+  workspaceTargetMode: "absolute-path";
+  mutableConfigTargets: string[];
 }
 
 export interface BindingSemantics {

--- a/src/core/verifier.ts
+++ b/src/core/verifier.ts
@@ -171,6 +171,38 @@ export function verify(targetDir: string, manifest?: Manifest): VerifyResult {
       message: `Pack type: ${manifest.packType}`,
     });
 
+    const hasPlacementContract =
+      Array.isArray(manifest.placement?.reservedRoots) &&
+      manifest.placement.reservedRoots.length >= 5 &&
+      typeof manifest.placement?.persistedManifestPath === "string" &&
+      manifest.placement.persistedManifestPath.length > 0;
+    checks.push({
+      name: "manifest_placement",
+      passed: hasPlacementContract,
+      message: hasPlacementContract
+        ? `Placement roots: ${manifest.placement.reservedRoots.join(", ")}`
+        : "Manifest placement contract missing or invalid",
+    });
+    if (!hasPlacementContract) {
+      warnings.push("Manifest placement contract missing or invalid");
+      runtimeReadinessIssues.push("Manifest placement contract missing or invalid");
+    }
+
+    const hasRebindingContract =
+      manifest.rebinding?.workspaceTargetMode === "absolute-path" &&
+      Array.isArray(manifest.rebinding?.mutableConfigTargets);
+    checks.push({
+      name: "manifest_rebinding",
+      passed: hasRebindingContract,
+      message: hasRebindingContract
+        ? `Rebinding targets: ${manifest.rebinding.mutableConfigTargets.join(", ")}`
+        : "Manifest rebinding contract missing or invalid",
+    });
+    if (!hasRebindingContract) {
+      warnings.push("Manifest rebinding contract missing or invalid");
+      runtimeReadinessIssues.push("Manifest rebinding contract missing or invalid");
+    }
+
     const packTypeContractErrors = validatePackTypeComponents(
       manifest.packType,
       manifest.harness.components

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -254,6 +254,9 @@ describe("export + import", () => {
     expect(result.manifest.image.adapter).toBe("openclaw");
     expect(result.manifest.lineage.parentImage).toBeNull();
     expect(result.manifest.lineage.layerOrder).toEqual([]);
+    expect(result.manifest.placement.persistedManifestPath).toBe(".harness-manifest.json");
+    expect(result.manifest.placement.reservedRoots).toEqual(["config", "workspace", "workspaces", "reports", "state"]);
+    expect(result.manifest.rebinding.workspaceTargetMode).toBe("absolute-path");
     expect(result.manifest.bindings.workspaces).toEqual([
       {
         agentId: "main",
@@ -262,6 +265,10 @@ describe("export + import", () => {
         configTargets: ["agents.defaults.workspace", "agents.list[main].workspace"],
         required: true,
       },
+    ]);
+    expect(result.manifest.rebinding.mutableConfigTargets).toEqual([
+      "agents.defaults.workspace",
+      "agents.list[main].workspace",
     ]);
     expect(result.manifest.harness.intent).toBe("agent-runtime-environment");
     expect(result.manifest.harness.targetProduct).toBe("openclaw");
@@ -519,6 +526,8 @@ describe("export + import", () => {
     expect(verifyResult.errors).toHaveLength(0);
     expect(verifyResult.checks.some(c => c.name === "manifest_image" && c.passed)).toBe(true);
     expect(verifyResult.checks.some(c => c.name === "manifest_lineage" && c.passed)).toBe(true);
+    expect(verifyResult.checks.some(c => c.name === "manifest_placement" && c.passed)).toBe(true);
+    expect(verifyResult.checks.some(c => c.name === "manifest_rebinding" && c.passed)).toBe(true);
     expect(verifyResult.checks.some(c => c.name === "binding_semantics" && c.passed)).toBe(true);
     expect(verifyResult.checks.some(c => c.name === "manifest_harness" && c.passed)).toBe(true);
   });
@@ -635,6 +644,21 @@ describe("verify", () => {
         parentImage: null,
         layerOrder: [],
       },
+      placement: {
+        reservedRoots: ["config", "workspace", "workspaces", "reports", "state"],
+        componentRoots: {
+          config: "config",
+          workspace: "workspace",
+          workspaces: "workspaces",
+          reports: "reports",
+          state: "state",
+        },
+        persistedManifestPath: ".harness-manifest.json",
+      },
+      rebinding: {
+        workspaceTargetMode: "absolute-path",
+        mutableConfigTargets: [],
+      },
       bindings: {
         workspaces: [],
       },
@@ -683,6 +707,21 @@ describe("verify", () => {
       lineage: {
         parentImage: null,
         layerOrder: [],
+      },
+      placement: {
+        reservedRoots: ["config", "workspace", "workspaces", "reports", "state"],
+        componentRoots: {
+          config: "config",
+          workspace: "workspace",
+          workspaces: "workspaces",
+          reports: "reports",
+          state: "state",
+        },
+        persistedManifestPath: ".harness-manifest.json",
+      },
+      rebinding: {
+        workspaceTargetMode: "absolute-path",
+        mutableConfigTargets: [],
       },
       bindings: {
         workspaces: [],


### PR DESCRIPTION
Closes #46

Promote rebinding rules and component placement from implementation detail to explicit harness image specification.

Validation:
- `npm run build`
- `npm test`
- `./scripts/run-agent-preflight.sh`
- `npm run build`
- `npm test`