### PR TITLE
Define export policy for inspect recommendations, warnings, and hard stops

### DIFF
--- a/.codex/pm/issue-state/51-define-export-policy-for-inspect-recommendations-warnings-and-hard-stops.md
+++ b/.codex/pm/issue-state/51-define-export-policy-for-inspect-recommendations-warnings-and-hard-stops.md
@@ -1,0 +1,33 @@
+---
+type: issue_state
+issue: 51
+task: .codex/pm/tasks/product-direction/define-export-policy-for-inspect-recommendations-warnings-and-hard-stops.md
+title: Define export policy for inspect recommendations, warnings, and hard stops
+status: in_progress
+---
+
+## Summary
+
+Define the product policy that turns inspect recommendations and pack-type risk signals into explicit export behavior.
+
+HarnessHub now has a stronger template vs instance contract, but users still need clearer product behavior when inspect recommends `instance` and export is asked to produce `template`. The CLI should make those boundaries predictable instead of relying only on free-form warnings.
+
+## Validated Facts
+
+- export behavior is explicit when inspect recommendations and requested pack type diverge
+- the user-facing contract is clearer than the current warning-only behavior
+- the implementation remains within current MVP scope and does not require a new runtime adapter
+
+## Open Questions
+
+-
+
+## Next Steps
+
+- define when export should warn, require explicit override, or refuse a pack-type choice
+- align inspect recommendations with export defaults and user intent
+- keep the first implementation aligned with the current OpenClaw-oriented MVP
+
+## Artifacts
+
+-

--- a/.codex/pm/tasks/product-direction/define-export-policy-for-inspect-recommendations-warnings-and-hard-stops.md
+++ b/.codex/pm/tasks/product-direction/define-export-policy-for-inspect-recommendations-warnings-and-hard-stops.md
@@ -1,0 +1,39 @@
+---
+type: task
+epic: product-direction
+slug: define-export-policy-for-inspect-recommendations-warnings-and-hard-stops
+title: Define export policy for inspect recommendations, warnings, and hard stops
+status: done
+task_type: implementation
+labels: feature,design
+issue: 51
+state_path: .codex/pm/issue-state/51-define-export-policy-for-inspect-recommendations-warnings-and-hard-stops.md
+---
+
+## Context
+
+Define the product policy that turns inspect recommendations and pack-type risk signals into explicit export behavior.
+
+HarnessHub now has a stronger template vs instance contract, but users still need clearer product behavior when inspect recommends `instance` and export is asked to produce `template`. The CLI should make those boundaries predictable instead of relying only on free-form warnings.
+
+## Deliverable
+
+Define the product policy that turns inspect recommendations and pack-type risk signals into explicit export behavior.
+
+## Scope
+
+- define when export should warn, require explicit override, or refuse a pack-type choice
+- align inspect recommendations with export defaults and user intent
+- keep the first implementation aligned with the current OpenClaw-oriented MVP
+
+## Acceptance Criteria
+
+- export behavior is explicit when inspect recommendations and requested pack type diverge
+- the user-facing contract is clearer than the current warning-only behavior
+- the implementation remains within current MVP scope and does not require a new runtime adapter
+
+## Validation
+
+-
+
+## Implementation Notes

--- a/scripts/run-openclaw-e2e-validation.sh
+++ b/scripts/run-openclaw-e2e-validation.sh
@@ -22,7 +22,7 @@ mkdir -p "$RUN_DIR" "$(dirname "$REPORT_JSON")" "$(dirname "$REPORT_MD")"
 npm run build >/dev/null
 
 node dist/cli.js inspect -p "$SOURCE_DIR" -f json >"$RUN_DIR/inspect.json"
-node dist/cli.js export -p "$SOURCE_DIR" -o "$PACK_FILE" -t template -f json >"$RUN_DIR/export.json"
+node dist/cli.js export -p "$SOURCE_DIR" -o "$PACK_FILE" -t template --allow-pack-type-override -f json >"$RUN_DIR/export.json"
 node dist/cli.js import "$PACK_FILE" -t "$TARGET_DIR" -f json >"$RUN_DIR/import.json"
 node dist/cli.js verify -p "$TARGET_DIR" -f json >"$RUN_DIR/verify.json"
 tar -xOf "$PACK_FILE" manifest.json >"$RUN_DIR/manifest.json"
@@ -74,6 +74,7 @@ const summary = {
     riskLevel: exported.riskLevel,
     fileCount: exported.fileCount,
     totalSize: exported.totalSize,
+    policyWarnings: (exported.policyWarnings ?? []).map(sanitizeText),
   },
   manifest: {
     schemaVersion: manifest.schemaVersion,
@@ -132,6 +133,12 @@ const md = [
   `- Risk level: \`${summary.export.riskLevel}\``,
   `- File count: \`${summary.export.fileCount}\``,
   `- Total size: \`${summary.export.totalSize}\` bytes`,
+  "",
+  "## Export Policy",
+  "",
+  ...(summary.export.policyWarnings.length > 0
+    ? summary.export.policyWarnings.map((warning) => `- ${warning}`)
+    : ["- none"]),
   "",
   "## Manifest",
   "",

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -7,6 +7,7 @@ export const exportCommand = new Command("export")
   .option("-p, --path <path>", "Path to OpenClaw state directory")
   .option("-o, --output <path>", "Output file path")
   .option("-t, --type <type>", "Pack type: template or instance", "template")
+  .option("--allow-pack-type-override", "Allow exporting a pack type that diverges from inspect recommendations")
   .option("-f, --format <format>", "Output format: text or json", "text")
   .action(async (opts) => {
     const format = opts.format as OutputFormat;
@@ -28,6 +29,7 @@ export const exportCommand = new Command("export")
         sourcePath: opts.path,
         outputPath: opts.output,
         packType,
+        allowPackTypeOverride: Boolean(opts.allowPackTypeOverride),
       });
 
       if (format === "json") {
@@ -40,6 +42,7 @@ export const exportCommand = new Command("export")
           fileCount: result.fileCount,
           totalSize: result.totalSize,
           warnings: result.warnings,
+          policyWarnings: result.policyWarnings,
         }, null, 2));
       } else {
         console.log("");

--- a/src/core/packer.ts
+++ b/src/core/packer.ts
@@ -292,6 +292,7 @@ interface ExportOptions {
   sourcePath?: string;
   outputPath?: string;
   packType: PackType;
+  allowPackTypeOverride?: boolean;
 }
 
 interface CollectedFile {
@@ -306,6 +307,7 @@ interface ExportResult {
   fileCount: number;
   totalSize: number;
   warnings: string[];
+  policyWarnings: string[];
 }
 
 export async function exportPack(options: ExportOptions): Promise<ExportResult> {
@@ -386,9 +388,23 @@ export async function exportPack(options: ExportOptions): Promise<ExportResult> 
     riskLevel: assessRisk(inspectResult.sensitiveFlags, packType),
   };
   const warnings: string[] = [];
+  const policyWarnings: string[] = [];
   if (inspectResult.recommendedPackType !== packType) {
-    warnings.push(
-      `Inspect recommended ${inspectResult.recommendedPackType}; exporting ${packType} applies the explicit ${packType} contract instead.`
+    const divergenceMessage =
+      `Inspect recommended ${inspectResult.recommendedPackType}; exporting ${packType} diverges from the recommended pack type.`;
+    if (inspectResult.recommendedPackType === "instance" && packType === "template" && !options.allowPackTypeOverride) {
+      throw new Error(`${divergenceMessage} Re-run with explicit pack-type override to allow a template downgrade.`);
+    }
+    policyWarnings.push(divergenceMessage);
+  }
+  if (packType === "instance" && inspectResult.recommendedPackType === "template") {
+    policyWarnings.push(
+      "Exporting instance for a source that qualifies for template will retain additional state for migration-oriented use."
+    );
+  }
+  if (packType === "instance" && manifest.riskLevel === "trusted-migration-only") {
+    policyWarnings.push(
+      "Instance export is trusted-migration-only and may retain sensitive runtime state."
     );
   }
   const packTypeContractErrors = validatePackTypeComponents(packType, manifest.harness.components);
@@ -467,7 +483,14 @@ export async function exportPack(options: ExportOptions): Promise<ExportResult> 
       fs.readdirSync(stagingDir)
     );
 
-    return { outputFile, manifest, fileCount: filesToExport.length, totalSize, warnings };
+    return {
+      outputFile,
+      manifest,
+      fileCount: filesToExport.length,
+      totalSize,
+      warnings: [...policyWarnings, ...warnings],
+      policyWarnings,
+    };
   } finally {
     fs.rmSync(stagingDir, { recursive: true, force: true });
   }

--- a/test/cli-integration.test.ts
+++ b/test/cli-integration.test.ts
@@ -102,6 +102,21 @@ describe("harness CLI integration", () => {
     expect(data.checks.some((check: { name: string; passed: boolean }) => check.name === "manifest_schema" && check.passed)).toBe(true);
   });
 
+  it("requires explicit override when exporting template against an instance recommendation", () => {
+    const sourceDir = path.join(tmpDir, "source");
+    const packFile = path.join(tmpDir, "template.harness");
+    createInstanceSource(sourceDir);
+
+    const blocked = runCli(["export", "-p", sourceDir, "-o", packFile, "-t", "template", "-f", "json"]);
+    expect(blocked.status).toBe(1);
+    expect(JSON.parse(blocked.stdout).error).toContain("explicit pack-type override");
+
+    const allowed = runCli(["export", "-p", sourceDir, "-o", packFile, "-t", "template", "--allow-pack-type-override", "-f", "json"]);
+    expect(allowed.status).toBe(0);
+    const data = JSON.parse(allowed.stdout);
+    expect(data.policyWarnings.some((warning: string) => warning.includes("Inspect recommended instance"))).toBe(true);
+  });
+
   it("runs an instance roundtrip and preserves sensitive structure", () => {
     const sourceDir = path.join(tmpDir, "source");
     const targetDir = path.join(tmpDir, "target");

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -308,10 +308,17 @@ describe("export + import", () => {
     const instanceDir = createMockInstanceWithSensitiveData(path.join(tmpDir, "sensitive"));
     const outputFile = path.join(tmpDir, "template.harness");
 
+    await expect(exportPack({
+      sourcePath: instanceDir,
+      outputPath: outputFile,
+      packType: "template",
+    })).rejects.toThrow(/explicit pack-type override/);
+
     const result = await exportPack({
       sourcePath: instanceDir,
       outputPath: outputFile,
       packType: "template",
+      allowPackTypeOverride: true,
     });
 
     const paths = result.manifest.includedPaths;
@@ -341,6 +348,7 @@ describe("export + import", () => {
       sourcePath: instanceDir,
       outputPath: outputFile,
       packType: "template",
+      allowPackTypeOverride: true,
     });
 
     expect(result.manifest.harness.components).not.toContain("agents");
@@ -351,6 +359,19 @@ describe("export + import", () => {
     expect(result.manifest.includedPaths.some((p) => p.startsWith("credentials/"))).toBe(false);
     expect(result.manifest.includedPaths.some((p) => p.startsWith("memory/"))).toBe(false);
     expect(result.warnings.some((warning) => warning.includes("Inspect recommended instance"))).toBe(true);
+  });
+
+  it("instance export warns when template would be sufficient", async () => {
+    const instanceDir = createMockInstance(path.join(tmpDir, "template-source"));
+    const outputFile = path.join(tmpDir, "template-source-instance.harness");
+
+    const result = await exportPack({
+      sourcePath: instanceDir,
+      outputPath: outputFile,
+      packType: "instance",
+    });
+
+    expect(result.policyWarnings.some((warning) => warning.includes("qualifies for template"))).toBe(true);
   });
 
   it("instance pack preserves agent directory structure", async () => {

--- a/test/openclaw-e2e-script.test.ts
+++ b/test/openclaw-e2e-script.test.ts
@@ -54,11 +54,15 @@ describe("run-openclaw-e2e-validation.sh", () => {
     const report = JSON.parse(fs.readFileSync(reportJson, "utf8"));
     expect(report.sourceDir).toBe(sourceDir);
     expect(report.export.success).toBe(true);
+    expect(report.export.policyWarnings).toEqual(
+      expect.arrayContaining([expect.stringContaining("Inspect recommended instance")]),
+    );
     expect(report.manifest.image.adapter).toBe("openclaw");
     expect(report.verify.valid).toBe(true);
 
     const markdown = fs.readFileSync(reportMd, "utf8");
     expect(markdown).toContain("Artifact path:");
+    expect(markdown).toContain("## Export Policy");
     expect(markdown).toContain("Verify valid: `true`");
 
     fs.rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
Closes #51

Define the product policy that turns inspect recommendations and pack-type risk signals into explicit export behavior.

Validation:
- `npm run build`
- `npm test`
- `./scripts/run-agent-preflight.sh`
- `./scripts/run-cli-smoke.sh`