### PR TITLE
Refine verification into explicit readiness classes

### DIFF
--- a/.codex/pm/issue-state/53-refine-verification-into-explicit-readiness-classes.md
+++ b/.codex/pm/issue-state/53-refine-verification-into-explicit-readiness-classes.md
@@ -1,0 +1,33 @@
+---
+type: issue_state
+issue: 53
+task: .codex/pm/tasks/product-direction/refine-verification-into-explicit-readiness-classes.md
+title: Refine verification into explicit readiness classes
+status: in_progress
+---
+
+## Summary
+
+Refine verification semantics beyond a boolean runtime-ready signal into explicit readiness classes that describe what kind of follow-up, if any, is still required.
+
+HarnessHub now distinguishes structural restore from runtime readiness, but the current runtime-ready model is still binary. A richer readiness model would make verify output more actionable without expanding runtime scope.
+
+## Validated Facts
+
+- verify output can express more than a simple ready/not-ready distinction
+- current runtime-readiness issues are mapped into explicit readiness classes
+- the model improves operator clarity while staying within the MVP image scope
+
+## Open Questions
+
+-
+
+## Next Steps
+
+- define explicit readiness classes for imported images
+- map current runtime-readiness issues into those classes
+- update verification output and tests to reflect the clearer readiness model
+
+## Artifacts
+
+-

--- a/.codex/pm/tasks/product-direction/refine-verification-into-explicit-readiness-classes.md
+++ b/.codex/pm/tasks/product-direction/refine-verification-into-explicit-readiness-classes.md
@@ -1,0 +1,39 @@
+---
+type: task
+epic: product-direction
+slug: refine-verification-into-explicit-readiness-classes
+title: Refine verification into explicit readiness classes
+status: done
+task_type: implementation
+labels: feature,design
+issue: 53
+state_path: .codex/pm/issue-state/53-refine-verification-into-explicit-readiness-classes.md
+---
+
+## Context
+
+Refine verification semantics beyond a boolean runtime-ready signal into explicit readiness classes that describe what kind of follow-up, if any, is still required.
+
+HarnessHub now distinguishes structural restore from runtime readiness, but the current runtime-ready model is still binary. A richer readiness model would make verify output more actionable without expanding runtime scope.
+
+## Deliverable
+
+Refine verification semantics beyond a boolean runtime-ready signal into explicit readiness classes that describe what kind of follow-up, if any, is still required.
+
+## Scope
+
+- define explicit readiness classes for imported images
+- map current runtime-readiness issues into those classes
+- update verification output and tests to reflect the clearer readiness model
+
+## Acceptance Criteria
+
+- verify output can express more than a simple ready/not-ready distinction
+- current runtime-readiness issues are mapped into explicit readiness classes
+- the model improves operator clarity while staying within the MVP image scope
+
+## Validation
+
+-
+
+## Implementation Notes

--- a/scripts/run-openclaw-e2e-validation.sh
+++ b/scripts/run-openclaw-e2e-validation.sh
@@ -92,6 +92,8 @@ const summary = {
   },
   verify: {
     valid: verify.valid,
+    readinessClass: verify.readinessClass,
+    readinessSummary: sanitizeText(verify.readinessSummary ?? ""),
     runtimeReady: verify.runtimeReady,
     checkNames: (verify.checks ?? []).map((check) => check.name),
     runtimeReadinessIssues: (verify.runtimeReadinessIssues ?? []).map(sanitizeText),
@@ -156,7 +158,9 @@ const md = [
   `- Imported target: \`${summary.import.targetDir}\``,
   `- Imported file count: \`${summary.import.fileCount}\``,
   `- Verify valid: \`${summary.verify.valid}\``,
+  `- Readiness class: \`${summary.verify.readinessClass}\``,
   `- Runtime ready: \`${summary.verify.runtimeReady}\``,
+  `- Readiness summary: ${summary.verify.readinessSummary}`,
   `- Verify checks: \`${summary.verify.checkNames.join(", ")}\``,
   "",
   "## Warnings",

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -152,11 +152,18 @@ export interface InstanceStructure {
 export interface VerifyResult {
   valid: boolean;
   runtimeReady: boolean;
+  readinessClass: ReadinessClass;
+  readinessSummary: string;
   runtimeReadinessIssues: string[];
   checks: VerifyCheck[];
   warnings: string[];
   errors: string[];
 }
+
+export type ReadinessClass =
+  | "runtime_ready"
+  | "manual_steps_required"
+  | "structurally_invalid";
 
 export interface VerifyCheck {
   name: string;

--- a/src/core/verifier.ts
+++ b/src/core/verifier.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import JSON5 from "json5";
-import type { Manifest, VerifyResult, VerifyCheck } from "./types.js";
+import type { Manifest, VerifyResult, VerifyCheck, ReadinessClass } from "./types.js";
 import { SCHEMA_VERSION } from "./types.js";
 import { openClawAdapter } from "./adapters/openclaw.js";
 import { validateManifestContract } from "./manifest.js";
@@ -30,7 +30,7 @@ export function verify(targetDir: string, manifest?: Manifest): VerifyResult {
   if (!dirExists) {
     errors.push("Target directory does not exist");
     runtimeReadinessIssues.push("Target directory does not exist");
-    return { valid: false, runtimeReady: false, runtimeReadinessIssues, checks, warnings, errors };
+    return finalizeVerifyResult(checks, warnings, errors, runtimeReadinessIssues);
   }
 
   // Check 2: Config file exists
@@ -150,7 +150,7 @@ export function verify(targetDir: string, manifest?: Manifest): VerifyResult {
     if (manifestContractErrors.length > 0) {
       errors.push(...manifestContractErrors.map((error: string) => `Manifest contract error: ${error}`));
       runtimeReadinessIssues.push(...manifestContractErrors.map((error: string) => `Manifest contract error: ${error}`));
-      return { valid: false, runtimeReady: false, runtimeReadinessIssues, checks, warnings, errors };
+      return finalizeVerifyResult(checks, warnings, errors, runtimeReadinessIssues);
     }
 
     const schemaMatch = manifest.schemaVersion === SCHEMA_VERSION;
@@ -388,7 +388,49 @@ export function verify(targetDir: string, manifest?: Manifest): VerifyResult {
   const valid = errors.length === 0 && checks.every(
     c => c.passed || !["directory_exists", "workspace_exists"].includes(c.name)
   );
-  const runtimeReady = valid && runtimeReadinessIssues.length === 0;
+  return finalizeVerifyResult(checks, warnings, errors, runtimeReadinessIssues, valid);
+}
 
-  return { valid, runtimeReady, runtimeReadinessIssues, checks, warnings, errors };
+function finalizeVerifyResult(
+  checks: VerifyCheck[],
+  warnings: string[],
+  errors: string[],
+  runtimeReadinessIssues: string[],
+  valid = errors.length === 0 && checks.every(
+    (check) => check.passed || !["directory_exists", "workspace_exists"].includes(check.name)
+  ),
+): VerifyResult {
+  const readinessClass = classifyReadiness(valid, runtimeReadinessIssues);
+  const runtimeReady = readinessClass === "runtime_ready";
+  return {
+    valid,
+    runtimeReady,
+    readinessClass,
+    readinessSummary: summarizeReadiness(readinessClass),
+    runtimeReadinessIssues,
+    checks,
+    warnings,
+    errors,
+  };
+}
+
+function classifyReadiness(valid: boolean, runtimeReadinessIssues: string[]): ReadinessClass {
+  if (!valid) {
+    return "structurally_invalid";
+  }
+  if (runtimeReadinessIssues.length > 0) {
+    return "manual_steps_required";
+  }
+  return "runtime_ready";
+}
+
+function summarizeReadiness(readinessClass: ReadinessClass): string {
+  switch (readinessClass) {
+    case "runtime_ready":
+      return "Imported harness is structurally valid and ready to run without additional manual steps.";
+    case "manual_steps_required":
+      return "Imported harness is structurally valid but still needs manual follow-up before it is runtime-ready.";
+    case "structurally_invalid":
+      return "Imported harness is not structurally valid yet and cannot be treated as runtime-ready.";
+  }
 }

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -152,7 +152,9 @@ export function printVerifyResult(result: Record<string, unknown>, format: Outpu
   console.log("=== HarnessHub Verify ===");
   console.log("");
   console.log(`  Structural restore: ${r.valid ? "YES" : "NO"}`);
+  console.log(`  Readiness class:    ${r.readinessClass}`);
   console.log(`  Runtime ready:      ${r.runtimeReady ? "YES" : "NO"}`);
+  console.log(`  Readiness summary:  ${r.readinessSummary}`);
   console.log("");
 
   if (r.checks.length > 0) {

--- a/test/cli-integration.test.ts
+++ b/test/cli-integration.test.ts
@@ -99,6 +99,7 @@ describe("harness CLI integration", () => {
     const data = JSON.parse(verifyResult.stdout);
     expect(data.valid).toBe(true);
     expect(data.runtimeReady).toBe(true);
+    expect(data.readinessClass).toBe("runtime_ready");
     expect(data.checks.some((check: { name: string; passed: boolean }) => check.name === "manifest_schema" && check.passed)).toBe(true);
   });
 
@@ -133,6 +134,7 @@ describe("harness CLI integration", () => {
     const data = JSON.parse(verifyResult.stdout);
     expect(data.valid).toBe(true);
     expect(data.runtimeReady).toBe(true);
+    expect(data.readinessClass).toBe("runtime_ready");
   });
 
   it("returns a JSON error when importing a missing pack file", () => {
@@ -148,6 +150,7 @@ describe("harness CLI integration", () => {
     const data = JSON.parse(result.stdout);
     expect(data.valid).toBe(false);
     expect(data.runtimeReady).toBe(false);
+    expect(data.readinessClass).toBe("structurally_invalid");
     expect(data.errors).toContain("Target directory does not exist");
   });
 });

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -544,6 +544,7 @@ describe("export + import", () => {
     const verifyResult = verify(targetDir, importResult.manifest);
     expect(verifyResult.valid).toBe(true);
     expect(verifyResult.runtimeReady).toBe(true);
+    expect(verifyResult.readinessClass).toBe("runtime_ready");
     expect(verifyResult.errors).toHaveLength(0);
     expect(verifyResult.checks.some(c => c.name === "manifest_image" && c.passed)).toBe(true);
     expect(verifyResult.checks.some(c => c.name === "manifest_lineage" && c.passed)).toBe(true);
@@ -572,6 +573,7 @@ describe("export + import", () => {
     const verifyResult = verify(targetDir, importResult.manifest);
     expect(verifyResult.valid).toBe(true);
     expect(verifyResult.runtimeReady).toBe(true);
+    expect(verifyResult.readinessClass).toBe("runtime_ready");
     expect(verifyResult.errors).toHaveLength(0);
     expect(verifyResult.checks.some(c => c.name === "manifest_image" && c.passed)).toBe(true);
     expect(verifyResult.checks.some(c => c.name === "binding_semantics" && c.passed)).toBe(true);
@@ -585,6 +587,7 @@ describe("verify", () => {
 
     expect(result.valid).toBe(true);
     expect(result.runtimeReady).toBe(true);
+    expect(result.readinessClass).toBe("runtime_ready");
     expect(result.errors).toHaveLength(0);
   });
 
@@ -592,6 +595,7 @@ describe("verify", () => {
     const result = verify(path.join(tmpDir, "nonexistent"));
     expect(result.valid).toBe(false);
     expect(result.runtimeReady).toBe(false);
+    expect(result.readinessClass).toBe("structurally_invalid");
     expect(result.errors.length).toBeGreaterThan(0);
   });
 
@@ -604,6 +608,7 @@ describe("verify", () => {
 
     const result = verify(dir);
     expect(result.runtimeReady).toBe(false);
+    expect(result.readinessClass).toBe("manual_steps_required");
     expect(result.warnings.some(w => w.includes("AGENTS.md"))).toBe(true);
   });
 
@@ -613,6 +618,7 @@ describe("verify", () => {
 
     expect(result.checks.some(c => c.name === "agents_present" && c.passed)).toBe(true);
     expect(result.runtimeReady).toBe(true);
+    expect(result.readinessClass).toBe("runtime_ready");
   });
 
   it("fails when manifest contract metadata is missing", () => {
@@ -645,6 +651,7 @@ describe("verify", () => {
 
     expect(result.valid).toBe(false);
     expect(result.runtimeReady).toBe(false);
+    expect(result.readinessClass).toBe("structurally_invalid");
     expect(result.checks.some(c => c.name === "manifest_contract" && !c.passed)).toBe(true);
     expect(result.errors.some((error) => error.includes("image must be an object"))).toBe(true);
     expect(result.errors.some((error) => error.includes("harness must be an object"))).toBe(true);
@@ -710,6 +717,7 @@ describe("verify", () => {
     } as any);
 
     expect(result.valid).toBe(false);
+    expect(result.readinessClass).toBe("structurally_invalid");
     expect(result.checks.some((check) => check.name === "manifest_contract" && !check.passed)).toBe(true);
     expect(result.errors.some((error) => error.includes("image.adapter"))).toBe(true);
   });
@@ -775,6 +783,7 @@ describe("verify", () => {
 
     expect(result.valid).toBe(false);
     expect(result.runtimeReady).toBe(false);
+    expect(result.readinessClass).toBe("structurally_invalid");
     expect(result.checks.some((check) => check.name === "pack_type_contract" && !check.passed)).toBe(true);
     expect(result.errors.some((error) => error.includes("template packs must not include agents"))).toBe(true);
   });

--- a/test/openclaw-e2e-script.test.ts
+++ b/test/openclaw-e2e-script.test.ts
@@ -59,10 +59,12 @@ describe("run-openclaw-e2e-validation.sh", () => {
     );
     expect(report.manifest.image.adapter).toBe("openclaw");
     expect(report.verify.valid).toBe(true);
+    expect(report.verify.readinessClass).toBe("runtime_ready");
 
     const markdown = fs.readFileSync(reportMd, "utf8");
     expect(markdown).toContain("Artifact path:");
     expect(markdown).toContain("## Export Policy");
+    expect(markdown).toContain("Readiness class: `runtime_ready`");
     expect(markdown).toContain("Verify valid: `true`");
 
     fs.rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
Closes #53

Refine verification semantics beyond a boolean runtime-ready signal into explicit readiness classes that describe what kind of follow-up, if any, is still required.

Validation:
- `npm run build`
- `npm test`
- `./scripts/run-agent-preflight.sh`
- `./scripts/run-cli-smoke.sh`