### PR TITLE
Add regression assertions against the real OpenClaw validation baseline

### DIFF
--- a/.codex/pm/issue-state/54-add-regression-assertions-against-the-real-openclaw-validation-baseline.md
+++ b/.codex/pm/issue-state/54-add-regression-assertions-against-the-real-openclaw-validation-baseline.md
@@ -1,0 +1,33 @@
+---
+type: issue_state
+issue: 54
+task: .codex/pm/tasks/product-direction/add-regression-assertions-against-the-real-openclaw-validation-baseline.md
+title: Add regression assertions against the real OpenClaw validation baseline
+status: in_progress
+---
+
+## Summary
+
+Turn the real OpenClaw end-to-end validation record into a stronger regression baseline so future changes can be checked against a concrete artifact shape and verify outcome.
+
+HarnessHub now has a real local validation artifact and committed summary, but the baseline is still mostly documentary. More explicit regression assertions would make artifact drift easier to detect.
+
+## Validated Facts
+
+- the real OpenClaw validation record is used as more than a narrative artifact
+- future drift in key artifact semantics is easier to detect locally
+- the regression layer remains compatible with the current local-only validation setup
+
+## Open Questions
+
+-
+
+## Next Steps
+
+- define which parts of the real validation baseline should remain stable enough to assert in-repo
+- add regression checks around artifact shape, manifest shape, or verify outcome where appropriate
+- keep the solution safe for local development and compatible with the existing validation script
+
+## Artifacts
+
+-

--- a/.codex/pm/tasks/product-direction/add-regression-assertions-against-the-real-openclaw-validation-baseline.md
+++ b/.codex/pm/tasks/product-direction/add-regression-assertions-against-the-real-openclaw-validation-baseline.md
@@ -1,0 +1,39 @@
+---
+type: task
+epic: product-direction
+slug: add-regression-assertions-against-the-real-openclaw-validation-baseline
+title: Add regression assertions against the real OpenClaw validation baseline
+status: done
+task_type: implementation
+labels: test,design
+issue: 54
+state_path: .codex/pm/issue-state/54-add-regression-assertions-against-the-real-openclaw-validation-baseline.md
+---
+
+## Context
+
+Turn the real OpenClaw end-to-end validation record into a stronger regression baseline so future changes can be checked against a concrete artifact shape and verify outcome.
+
+HarnessHub now has a real local validation artifact and committed summary, but the baseline is still mostly documentary. More explicit regression assertions would make artifact drift easier to detect.
+
+## Deliverable
+
+Turn the real OpenClaw end-to-end validation record into a stronger regression baseline so future changes can be checked against a concrete artifact shape and verify outcome.
+
+## Scope
+
+- define which parts of the real validation baseline should remain stable enough to assert in-repo
+- add regression checks around artifact shape, manifest shape, or verify outcome where appropriate
+- keep the solution safe for local development and compatible with the existing validation script
+
+## Acceptance Criteria
+
+- the real OpenClaw validation record is used as more than a narrative artifact
+- future drift in key artifact semantics is easier to detect locally
+- the regression layer remains compatible with the current local-only validation setup
+
+## Validation
+
+-
+
+## Implementation Notes

--- a/docs/validation/openclaw-e2e-validation.json
+++ b/docs/validation/openclaw-e2e-validation.json
@@ -1,9 +1,9 @@
 {
-  "validatedAt": "2026-03-12T06:37:07.412Z",
+  "validatedAt": "2026-03-12T07:51:35.298Z",
   "sourceDir": "~/.openclaw",
-  "artifactPath": ".artifacts/openclaw-e2e/20260312T063701Z/openclaw-template.harness",
-  "artifactSha256": "e15876aa51aef57ba57828481ce457a9adffe95610e3ceeccfdc37707e384cb4",
-  "artifactSizeBytes": 4154926,
+  "artifactPath": ".artifacts/openclaw-e2e/20260312T075132Z/openclaw-template.harness",
+  "artifactSha256": "9dbcdb3878de3a12c25c14e9499a55f862f26afdab869616f007be3ce0360015",
+  "artifactSizeBytes": 4071021,
   "inspect": {
     "detected": true,
     "product": "openclaw",
@@ -26,16 +26,19 @@
   },
   "export": {
     "success": true,
-    "packId": "64ceb066-b454-46b4-8755-88383a5817ab",
+    "packId": "b0e14d8c-2781-4364-9ed1-4c07084d0a28",
     "packType": "template",
     "riskLevel": "internal-only",
-    "fileCount": 343,
-    "totalSize": 7279282
+    "fileCount": 321,
+    "totalSize": 7011102,
+    "policyWarnings": [
+      "Inspect recommended instance; exporting template diverges from the recommended pack type."
+    ]
   },
   "manifest": {
     "schemaVersion": "0.5.0",
     "image": {
-      "imageId": "64ceb066-b454-46b4-8755-88383a5817ab",
+      "imageId": "b0e14d8c-2781-4364-9ed1-4c07084d0a28",
       "adapter": "openclaw"
     },
     "lineage": {
@@ -49,11 +52,8 @@
         "workspace",
         "config",
         "skills",
-        "agents",
-        "sessions",
         "cron",
         "extensions",
-        "browser",
         "completions"
       ]
     },
@@ -66,23 +66,29 @@
   },
   "import": {
     "success": true,
-    "targetDir": ".artifacts/openclaw-e2e/20260312T063701Z/imported",
-    "fileCount": 344,
+    "targetDir": ".artifacts/openclaw-e2e/20260312T075132Z/imported",
+    "fileCount": 322,
     "warnings": [
-      "Rebound workspace paths in openclaw.json to ./.artifacts/openclaw-e2e/20260312T063701Z/imported; JSON5 formatting/comments were normalized."
+      "Rebound workspace paths in openclaw.json to ./.artifacts/openclaw-e2e/20260312T075132Z/imported; JSON5 formatting/comments were normalized."
     ]
   },
   "verify": {
     "valid": true,
+    "readinessClass": "runtime_ready",
+    "readinessSummary": "Imported harness is structurally valid and ready to run without additional manual steps.",
+    "runtimeReady": true,
     "checkNames": [
       "directory_exists",
       "config_exists",
       "workspace_exists",
       "workspace_file_agents.md",
       "config_valid",
-      "agents_present",
+      "manifest_contract",
       "manifest_schema",
       "manifest_pack_type",
+      "manifest_placement",
+      "manifest_rebinding",
+      "pack_type_contract",
       "manifest_image",
       "manifest_lineage",
       "manifest_harness",
@@ -91,9 +97,8 @@
       "file_count",
       "workspace_readable"
     ],
-    "warnings": [
-      "Agent \"main\" missing agent/ subdirectory"
-    ],
+    "runtimeReadinessIssues": [],
+    "warnings": [],
     "errors": []
   }
 }

--- a/docs/validation/openclaw-e2e-validation.md
+++ b/docs/validation/openclaw-e2e-validation.md
@@ -2,11 +2,11 @@
 
 This record comes from a real local `~/.openclaw` validation run using the current `harness` CLI path.
 
-- Validated at: `2026-03-12T06:37:07.412Z`
+- Validated at: `2026-03-12T07:51:35.298Z`
 - Source directory: `~/.openclaw`
-- Artifact path: `.artifacts/openclaw-e2e/20260312T063701Z/openclaw-template.harness`
-- Artifact sha256: `e15876aa51aef57ba57828481ce457a9adffe95610e3ceeccfdc37707e384cb4`
-- Artifact size: `4154926` bytes
+- Artifact path: `.artifacts/openclaw-e2e/20260312T075132Z/openclaw-template.harness`
+- Artifact sha256: `9dbcdb3878de3a12c25c14e9499a55f862f26afdab869616f007be3ce0360015`
+- Artifact size: `4071021` bytes
 
 ## Inspect
 
@@ -23,36 +23,43 @@ This record comes from a real local `~/.openclaw` validation run using the curre
 ## Export
 
 - Success: `true`
-- Pack ID: `64ceb066-b454-46b4-8755-88383a5817ab`
+- Pack ID: `b0e14d8c-2781-4364-9ed1-4c07084d0a28`
 - Pack type: `template`
 - Risk level: `internal-only`
-- File count: `343`
-- Total size: `7279282` bytes
+- File count: `321`
+- Total size: `7011102` bytes
+
+## Export Policy
+
+- Inspect recommended instance; exporting template diverges from the recommended pack type.
 
 ## Manifest
 
 - Schema version: `0.5.0`
 - Adapter: `openclaw`
-- Image ID: `64ceb066-b454-46b4-8755-88383a5817ab`
+- Image ID: `b0e14d8c-2781-4364-9ed1-4c07084d0a28`
 - Binding workspace count: `1`
 - Harness intent: `agent-runtime-environment`
 - Harness target product: `openclaw`
-- Harness components: `workspace, config, skills, agents, sessions, cron, extensions, browser, completions`
+- Harness components: `workspace, config, skills, cron, extensions, completions`
 
 ## Import And Verify
 
 - Import success: `true`
-- Imported target: `.artifacts/openclaw-e2e/20260312T063701Z/imported`
-- Imported file count: `344`
+- Imported target: `.artifacts/openclaw-e2e/20260312T075132Z/imported`
+- Imported file count: `322`
 - Verify valid: `true`
-- Verify checks: `directory_exists, config_exists, workspace_exists, workspace_file_agents.md, config_valid, agents_present, manifest_schema, manifest_pack_type, manifest_image, manifest_lineage, manifest_harness, workspace_bindings, binding_semantics, file_count, workspace_readable`
+- Readiness class: `runtime_ready`
+- Runtime ready: `true`
+- Readiness summary: Imported harness is structurally valid and ready to run without additional manual steps.
+- Verify checks: `directory_exists, config_exists, workspace_exists, workspace_file_agents.md, config_valid, manifest_contract, manifest_schema, manifest_pack_type, manifest_placement, manifest_rebinding, pack_type_contract, manifest_image, manifest_lineage, manifest_harness, workspace_bindings, binding_semantics, file_count, workspace_readable`
 
 ## Warnings
 
 - Inspect: Config contains API keys or tokens
 - Inspect: Agent auth-profiles.json detected (contains API credentials)
 - Inspect: Credentials directory exists
-- Import: Rebound workspace paths in openclaw.json to ./.artifacts/openclaw-e2e/20260312T063701Z/imported; JSON5 formatting/comments were normalized.
-- Verify: Agent "main" missing agent/ subdirectory
+- Import: Rebound workspace paths in openclaw.json to ./.artifacts/openclaw-e2e/20260312T075132Z/imported; JSON5 formatting/comments were normalized.
+- Verify: none
 
 The `.harness` artifact itself is retained only in the local `.artifacts/` directory and is intentionally not committed.

--- a/test/openclaw-baseline.test.ts
+++ b/test/openclaw-baseline.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const baselinePath = path.join(repoRoot, "docs", "validation", "openclaw-e2e-validation.json");
+
+describe("committed OpenClaw validation baseline", () => {
+  it("captures the expected stable semantics of the real validation artifact", () => {
+    const baseline = JSON.parse(fs.readFileSync(baselinePath, "utf8"));
+
+    expect(baseline.sourceDir).toBe("~/.openclaw");
+    expect(baseline.artifactPath).toMatch(/^\.artifacts\/openclaw-e2e\/.+\/openclaw-template\.harness$/);
+    expect(baseline.artifactSizeBytes).toBeGreaterThan(0);
+
+    expect(baseline.inspect).toMatchObject({
+      detected: true,
+      product: "openclaw",
+      configPath: "openclaw.json",
+      recommendedPackType: "instance",
+      riskAssessment: "trusted-migration-only",
+      workspaceDirs: ["workspace"],
+      agentIds: ["main"],
+    });
+    expect(baseline.inspect.warnings).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("API keys"),
+        expect.stringContaining("auth-profiles.json"),
+        expect.stringContaining("Credentials directory"),
+      ]),
+    );
+
+    expect(baseline.export).toMatchObject({
+      success: true,
+      packType: "template",
+      riskLevel: "internal-only",
+    });
+    expect(baseline.export.policyWarnings).toEqual([
+      "Inspect recommended instance; exporting template diverges from the recommended pack type.",
+    ]);
+
+    expect(baseline.manifest.schemaVersion).toBe("0.5.0");
+    expect(baseline.manifest.image.adapter).toBe("openclaw");
+    expect(baseline.manifest.lineage).toEqual({
+      parentImage: null,
+      layerOrder: [],
+    });
+    expect(baseline.manifest.harness).toEqual({
+      intent: "agent-runtime-environment",
+      targetProduct: "openclaw",
+      components: ["workspace", "config", "skills", "cron", "extensions", "completions"],
+    });
+    expect(baseline.manifest.bindingWorkspaceCount).toBe(1);
+
+    expect(baseline.import.success).toBe(true);
+    expect(baseline.import.targetDir).toMatch(/^\.artifacts\/openclaw-e2e\/.+\/imported$/);
+    expect(baseline.import.warnings).toEqual([
+      expect.stringContaining("Rebound workspace paths in openclaw.json"),
+    ]);
+
+    expect(baseline.verify).toMatchObject({
+      valid: true,
+      readinessClass: "runtime_ready",
+      readinessSummary: "Imported harness is structurally valid and ready to run without additional manual steps.",
+      runtimeReady: true,
+      runtimeReadinessIssues: [],
+      warnings: [],
+      errors: [],
+    });
+    expect(baseline.verify.checkNames).toEqual([
+      "directory_exists",
+      "config_exists",
+      "workspace_exists",
+      "workspace_file_agents.md",
+      "config_valid",
+      "manifest_contract",
+      "manifest_schema",
+      "manifest_pack_type",
+      "manifest_placement",
+      "manifest_rebinding",
+      "pack_type_contract",
+      "manifest_image",
+      "manifest_lineage",
+      "manifest_harness",
+      "workspace_bindings",
+      "binding_semantics",
+      "file_count",
+      "workspace_readable",
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #54

Turn the real OpenClaw end-to-end validation record into a stronger regression baseline so future changes can be checked against a concrete artifact shape and verify outcome.

Validation:
- `npm run build`
- `npm test`
- `./scripts/run-agent-preflight.sh`