### PR TITLE
Add remediation guidance to verify readiness output

### DIFF
--- a/.codex/pm/issue-state/61-add-remediation-guidance-to-verify-readiness-output.md
+++ b/.codex/pm/issue-state/61-add-remediation-guidance-to-verify-readiness-output.md
@@ -1,0 +1,33 @@
+---
+type: issue_state
+issue: 61
+task: .codex/pm/tasks/product-direction/add-remediation-guidance-to-verify-readiness-output.md
+title: Add remediation guidance to verify readiness output
+status: in_progress
+---
+
+## Summary
+
+Make verify output actionable by attaching remediation guidance to non-runtime-ready results.
+
+HarnessHub now reports explicit readiness classes, but operators still need to infer what to do next from raw readiness issues.
+
+## Validated Facts
+
+- verify output tells operators what follow-up is needed for current non-ready cases
+- the guidance is stable enough to test in repo
+- runtime-ready results remain concise and unchanged in meaning
+
+## Open Questions
+
+-
+
+## Next Steps
+
+- define stable remediation guidance for current verify failure and follow-up cases
+- surface the guidance in text and JSON verify output
+- keep the guidance within current MVP scope without introducing a policy engine
+
+## Artifacts
+
+-

--- a/.codex/pm/tasks/product-direction/add-remediation-guidance-to-verify-readiness-output.md
+++ b/.codex/pm/tasks/product-direction/add-remediation-guidance-to-verify-readiness-output.md
@@ -1,0 +1,39 @@
+---
+type: task
+epic: product-direction
+slug: add-remediation-guidance-to-verify-readiness-output
+title: Add remediation guidance to verify readiness output
+status: done
+task_type: implementation
+labels: feature,ux
+issue: 61
+state_path: .codex/pm/issue-state/61-add-remediation-guidance-to-verify-readiness-output.md
+---
+
+## Context
+
+Make verify output actionable by attaching remediation guidance to non-runtime-ready results.
+
+HarnessHub now reports explicit readiness classes, but operators still need to infer what to do next from raw readiness issues.
+
+## Deliverable
+
+Make verify output actionable by attaching remediation guidance to non-runtime-ready results.
+
+## Scope
+
+- define stable remediation guidance for current verify failure and follow-up cases
+- surface the guidance in text and JSON verify output
+- keep the guidance within current MVP scope without introducing a policy engine
+
+## Acceptance Criteria
+
+- verify output tells operators what follow-up is needed for current non-ready cases
+- the guidance is stable enough to test in repo
+- runtime-ready results remain concise and unchanged in meaning
+
+## Validation
+
+-
+
+## Implementation Notes

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -155,6 +155,7 @@ export interface VerifyResult {
   readinessClass: ReadinessClass;
   readinessSummary: string;
   runtimeReadinessIssues: string[];
+  remediationSteps: string[];
   checks: VerifyCheck[];
   warnings: string[];
   errors: string[];

--- a/src/core/verifier.ts
+++ b/src/core/verifier.ts
@@ -402,12 +402,14 @@ function finalizeVerifyResult(
 ): VerifyResult {
   const readinessClass = classifyReadiness(valid, runtimeReadinessIssues);
   const runtimeReady = readinessClass === "runtime_ready";
+  const remediationSteps = deriveRemediationSteps(readinessClass, runtimeReadinessIssues);
   return {
     valid,
     runtimeReady,
     readinessClass,
     readinessSummary: summarizeReadiness(readinessClass),
     runtimeReadinessIssues,
+    remediationSteps,
     checks,
     warnings,
     errors,
@@ -433,4 +435,58 @@ function summarizeReadiness(readinessClass: ReadinessClass): string {
     case "structurally_invalid":
       return "Imported harness is not structurally valid yet and cannot be treated as runtime-ready.";
   }
+}
+
+function deriveRemediationSteps(readinessClass: ReadinessClass, runtimeReadinessIssues: string[]): string[] {
+  if (readinessClass === "runtime_ready") {
+    return [];
+  }
+
+  const remediation = new Set<string>();
+
+  for (const issue of runtimeReadinessIssues) {
+    if (issue === "Target directory does not exist") {
+      remediation.add("Import the .harness package into the target directory before running verify.");
+      continue;
+    }
+    if (issue === "No OpenClaw config file found") {
+      remediation.add("Restore or regenerate openclaw.json before treating this import as runnable.");
+      continue;
+    }
+    if (issue.startsWith("Workspace file missing:")) {
+      remediation.add("Restore the required workspace instructions such as AGENTS.md, or re-export the source so the workspace contract is complete.");
+      continue;
+    }
+    if (issue === "Config file appears invalid" || issue.startsWith("Could not parse config to validate binding semantics:")) {
+      remediation.add("Repair openclaw.json to valid JSON/JSON5 and rerun import if rebinding did not complete cleanly.");
+      continue;
+    }
+    if (issue.startsWith("Missing imported workspace:") || issue.startsWith("Missing bound workspace target ")) {
+      remediation.add("Re-import the pack so all declared workspaces are materialized into the target directory.");
+      continue;
+    }
+    if (issue.startsWith("Default workspace binding not rebound") || issue.startsWith("Agent ") && issue.includes("workspace binding not rebound")) {
+      remediation.add("Re-import the pack so workspace bindings are rewritten into openclaw.json for the target path.");
+      continue;
+    }
+    if (
+      issue.startsWith("Manifest contract error:") ||
+      issue === "Manifest placement contract missing or invalid" ||
+      issue === "Manifest rebinding contract missing or invalid" ||
+      issue.startsWith("Pack type contract error:")
+    ) {
+      remediation.add("Re-export the source with the current harness CLI so the imported manifest and pack-type contract are regenerated.");
+      continue;
+    }
+    if (issue.includes("missing agent/ subdirectory")) {
+      remediation.add("Re-import an instance pack if runtime agent state is required, or restore the expected agent/ subdirectory manually.");
+      continue;
+    }
+  }
+
+  if (remediation.size === 0) {
+    remediation.add("Review the reported readiness issues and re-run import or export before treating the harness as runtime-ready.");
+  }
+
+  return [...remediation];
 }

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -181,6 +181,14 @@ export function printVerifyResult(result: Record<string, unknown>, format: Outpu
     }
   }
 
+  if (r.remediationSteps.length > 0) {
+    console.log("");
+    console.log("--- Recommended Next Steps ---");
+    for (const step of r.remediationSteps) {
+      console.log(`  -> ${step}`);
+    }
+  }
+
   if (r.errors.length > 0) {
     console.log("");
     console.log("--- Errors ---");

--- a/test/cli-integration.test.ts
+++ b/test/cli-integration.test.ts
@@ -152,5 +152,6 @@ describe("harness CLI integration", () => {
     expect(data.runtimeReady).toBe(false);
     expect(data.readinessClass).toBe("structurally_invalid");
     expect(data.errors).toContain("Target directory does not exist");
+    expect(data.remediationSteps).toContain("Import the .harness package into the target directory before running verify.");
   });
 });

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -588,6 +588,7 @@ describe("verify", () => {
     expect(result.valid).toBe(true);
     expect(result.runtimeReady).toBe(true);
     expect(result.readinessClass).toBe("runtime_ready");
+    expect(result.remediationSteps).toEqual([]);
     expect(result.errors).toHaveLength(0);
   });
 
@@ -597,6 +598,7 @@ describe("verify", () => {
     expect(result.runtimeReady).toBe(false);
     expect(result.readinessClass).toBe("structurally_invalid");
     expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.remediationSteps).toContain("Import the .harness package into the target directory before running verify.");
   });
 
   it("warns about missing workspace files", () => {
@@ -610,6 +612,7 @@ describe("verify", () => {
     expect(result.runtimeReady).toBe(false);
     expect(result.readinessClass).toBe("manual_steps_required");
     expect(result.warnings.some(w => w.includes("AGENTS.md"))).toBe(true);
+    expect(result.remediationSteps).toContain("Restore the required workspace instructions such as AGENTS.md, or re-export the source so the workspace contract is complete.");
   });
 
   it("detects agent directories during verification", () => {
@@ -655,6 +658,7 @@ describe("verify", () => {
     expect(result.checks.some(c => c.name === "manifest_contract" && !c.passed)).toBe(true);
     expect(result.errors.some((error) => error.includes("image must be an object"))).toBe(true);
     expect(result.errors.some((error) => error.includes("harness must be an object"))).toBe(true);
+    expect(result.remediationSteps).toContain("Re-export the source with the current harness CLI so the imported manifest and pack-type contract are regenerated.");
   });
 
   it("fails verification when the manifest contract is invalid", () => {


### PR DESCRIPTION
Closes #61

Make verify output actionable by attaching remediation guidance to non-runtime-ready results.

Validation:
- `npm run build`
- `npm test`
- `./scripts/run-agent-preflight.sh`
- `./scripts/run-cli-smoke.sh`