### PR TITLE
Close the inspect-to-export operator workflow

### DIFF
--- a/.codex/pm/issue-state/59-close-the-inspect-to-export-operator-workflow.md
+++ b/.codex/pm/issue-state/59-close-the-inspect-to-export-operator-workflow.md
@@ -1,0 +1,33 @@
+---
+type: issue_state
+issue: 59
+task: .codex/pm/tasks/product-direction/close-the-inspect-to-export-operator-workflow.md
+title: Close the inspect-to-export operator workflow
+status: in_progress
+---
+
+## Summary
+
+Make the inspect recommendation and export decision path feel like one coherent operator workflow.
+
+HarnessHub now has safer export policy, but the operator still has to infer the recommended next export command after inspect.
+
+## Validated Facts
+
+- the default operator path from inspect to export is explicit
+- template, instance, and override flows are documented and/or surfaced consistently
+- the documented quick path matches actual CLI behavior
+
+## Open Questions
+
+-
+
+## Next Steps
+
+- define the canonical operator path from inspect recommendation to export choice
+- surface the recommended next step in inspect and export UX or docs where appropriate
+- update smoke or CLI coverage around the documented workflow
+
+## Artifacts
+
+-

--- a/.codex/pm/tasks/product-direction/close-the-inspect-to-export-operator-workflow.md
+++ b/.codex/pm/tasks/product-direction/close-the-inspect-to-export-operator-workflow.md
@@ -1,0 +1,39 @@
+---
+type: task
+epic: product-direction
+slug: close-the-inspect-to-export-operator-workflow
+title: Close the inspect-to-export operator workflow
+status: done
+task_type: implementation
+labels: feature,docs,ux
+issue: 59
+state_path: .codex/pm/issue-state/59-close-the-inspect-to-export-operator-workflow.md
+---
+
+## Context
+
+Make the inspect recommendation and export decision path feel like one coherent operator workflow.
+
+HarnessHub now has safer export policy, but the operator still has to infer the recommended next export command after inspect.
+
+## Deliverable
+
+Make the inspect recommendation and export decision path feel like one coherent operator workflow.
+
+## Scope
+
+- define the canonical operator path from inspect recommendation to export choice
+- surface the recommended next step in inspect and export UX or docs where appropriate
+- update smoke or CLI coverage around the documented workflow
+
+## Acceptance Criteria
+
+- the default operator path from inspect to export is explicit
+- template, instance, and override flows are documented and/or surfaced consistently
+- the documented quick path matches actual CLI behavior
+
+## Validation
+
+-
+
+## Implementation Notes

--- a/README.md
+++ b/README.md
@@ -95,8 +95,11 @@ The four commands form a linear workflow:
 # 1. Inspect an OpenClaw instance
 harness inspect
 
-# 2. Export as a template pack (safe to share)
-harness export -t template -o my-agent.harness
+# 2. Follow the inspect recommendation
+#    - template recommendation: harness export -t template -o my-agent.harness
+#    - instance recommendation: harness export -t instance -o my-agent.harness
+#    - share-oriented override from an instance recommendation:
+#      harness export -t template --allow-pack-type-override -o my-agent.harness
 
 # 3. Import on another machine
 harness import my-agent.harness -t ~/.openclaw
@@ -126,6 +129,8 @@ harness inspect                  # auto-detect ~/.openclaw
 harness inspect -p /path/to/dir  # custom path
 harness inspect -f json          # JSON output
 ```
+
+`harness inspect` now returns the recommended next export command directly. When inspect recommends `instance`, it also surfaces the explicit `template` override form for intentional share-oriented export.
 
 ### `harness export`
 

--- a/scripts/run-cli-smoke.sh
+++ b/scripts/run-cli-smoke.sh
@@ -47,7 +47,18 @@ EOF
 
 npm run build >/dev/null
 
-node dist/cli.js inspect -p "$SRC_DIR" -f json >/dev/null
+INSPECT_JSON="$(node dist/cli.js inspect -p "$SRC_DIR" -f json)"
+echo "$INSPECT_JSON" | node -e '
+const data = JSON.parse(require("node:fs").readFileSync(0, "utf8"));
+if (data.recommendedPackType !== "template") {
+  console.error("inspect did not recommend template for the smoke fixture");
+  process.exit(1);
+}
+if (!data.workflow?.recommendedExportCommand?.includes("harness export")) {
+  console.error("inspect did not provide workflow guidance");
+  process.exit(1);
+}
+'
 node dist/cli.js export -p "$SRC_DIR" -o "$PACK_FILE" -t template -f json >/dev/null
 node dist/cli.js import "$PACK_FILE" -t "$TARGET_DIR" -f json >/dev/null
 

--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -1,7 +1,8 @@
 import { Command } from "commander";
+import path from "node:path";
 import { openClawAdapter } from "../core/adapters/openclaw.js";
 import { printInspectResult } from "../utils/output.js";
-import type { OutputFormat } from "../core/types.js";
+import type { InspectResult, OutputFormat } from "../core/types.js";
 
 export const inspectCommand = new Command("inspect")
   .description("Inspect an OpenClaw instance and report its structure and risks")
@@ -10,7 +11,7 @@ export const inspectCommand = new Command("inspect")
   .action((opts) => {
     const format = opts.format as OutputFormat;
     try {
-      const result = openClawAdapter.inspect(opts.path);
+      const result = withWorkflowGuidance(openClawAdapter.inspect(opts.path));
       printInspectResult(result as unknown as Record<string, unknown>, format);
       if (!result.detected) {
         process.exitCode = 1;
@@ -24,3 +25,28 @@ export const inspectCommand = new Command("inspect")
       process.exitCode = 1;
     }
   });
+
+function withWorkflowGuidance(result: InspectResult): InspectResult {
+  const sourcePath = path.resolve(result.stateDir);
+  const baseCommand = `harness export -p ${sourcePath} -t ${result.recommendedPackType} -o my-agent.harness`;
+
+  if (result.recommendedPackType === "instance") {
+    return {
+      ...result,
+      workflow: {
+        recommendedExportCommand: baseCommand,
+        recommendationSummary: "Inspect recommends an instance export for migration-oriented use because sensitive or runtime state was detected.",
+        overrideExportCommand: `harness export -p ${sourcePath} -t template --allow-pack-type-override -o my-agent.harness`,
+      },
+    };
+  }
+
+  return {
+    ...result,
+    workflow: {
+      recommendedExportCommand: baseCommand,
+      recommendationSummary: "Inspect recommends a template export for share-oriented use because the source qualifies for the template contract.",
+      overrideExportCommand: `harness export -p ${sourcePath} -t instance -o my-agent.harness`,
+    },
+  };
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -124,6 +124,13 @@ export interface InspectResult {
   recommendedPackType: PackType;
   riskAssessment: RiskLevel;
   warnings: string[];
+  workflow?: InspectWorkflow;
+}
+
+export interface InspectWorkflow {
+  recommendedExportCommand: string;
+  recommendationSummary: string;
+  overrideExportCommand?: string;
 }
 
 export interface InstanceStructure {

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -130,6 +130,15 @@ export function printInspectResult(result: Record<string, unknown>, format: Outp
   console.log("--- Recommendation ---");
   console.log(`  Pack type:    ${r.recommendedPackType}`);
   console.log(`  Risk level:   ${r.riskAssessment}`);
+  if (r.workflow) {
+    console.log("");
+    console.log("--- Next Step ---");
+    console.log(`  Summary:      ${r.workflow.recommendationSummary}`);
+    console.log(`  Export:       ${r.workflow.recommendedExportCommand}`);
+    if (r.workflow.overrideExportCommand) {
+      console.log(`  Override:     ${r.workflow.overrideExportCommand}`);
+    }
+  }
 
   if (r.warnings.length > 0) {
     console.log("");

--- a/test/cli-integration.test.ts
+++ b/test/cli-integration.test.ts
@@ -73,6 +73,20 @@ describe("harness CLI integration", () => {
     const data = JSON.parse(result.stdout);
     expect(data.detected).toBe(true);
     expect(data.recommendedPackType).toBe("template");
+    expect(data.workflow.recommendedExportCommand).toContain("harness export");
+    expect(data.workflow.recommendationSummary).toContain("template export");
+  });
+
+  it("returns instance-oriented workflow guidance when inspect recommends instance", () => {
+    const sourceDir = path.join(tmpDir, "source");
+    createInstanceSource(sourceDir);
+
+    const result = runCli(["inspect", "-p", sourceDir, "-f", "json"]);
+    expect(result.status).toBe(0);
+    const data = JSON.parse(result.stdout);
+    expect(data.recommendedPackType).toBe("instance");
+    expect(data.workflow.recommendedExportCommand).toContain("-t instance");
+    expect(data.workflow.overrideExportCommand).toContain("--allow-pack-type-override");
   });
 
   it("rejects an invalid export type with a JSON error", () => {


### PR DESCRIPTION
Closes #59

Make the inspect recommendation and export decision path feel like one coherent operator workflow.

Validation:
- `npm run build`
- `npm test`
- `./scripts/run-agent-preflight.sh`
- `./scripts/run-cli-smoke.sh`