### PR TITLE
Cut the first HarnessHub MVP release candidate

### DIFF
--- a/.codex/pm/issue-state/62-cut-the-first-harnesshub-mvp-release-candidate.md
+++ b/.codex/pm/issue-state/62-cut-the-first-harnesshub-mvp-release-candidate.md
@@ -1,0 +1,33 @@
+---
+type: issue_state
+issue: 62
+task: .codex/pm/tasks/product-direction/cut-the-first-harnesshub-mvp-release-candidate.md
+title: Cut the first HarnessHub MVP release candidate
+status: backlog
+---
+
+## Summary
+
+Prepare the first HarnessHub MVP release candidate around the current OpenClaw-first image lifecycle.
+
+The repository is close to MVP-complete in capability, but there is not yet a concrete release cut with notes and a stable acceptance path.
+
+## Validated Facts
+
+- the repository contains one explicit MVP release-candidate document or noteset
+- the release framing is consistent with the current MVP scope and non-goals
+- a fresh reader can understand what is in the first MVP release and how to validate it
+
+## Open Questions
+
+-
+
+## Next Steps
+
+- define the first MVP release candidate version framing
+- add release notes or release-candidate documentation scoped to the current MVP
+- document one clean acceptance path for a fresh operator
+
+## Artifacts
+
+-

--- a/.codex/pm/tasks/product-direction/cut-the-first-harnesshub-mvp-release-candidate.md
+++ b/.codex/pm/tasks/product-direction/cut-the-first-harnesshub-mvp-release-candidate.md
@@ -1,0 +1,39 @@
+---
+type: task
+epic: product-direction
+slug: cut-the-first-harnesshub-mvp-release-candidate
+title: Cut the first HarnessHub MVP release candidate
+status: done
+task_type: implementation
+labels: docs,release
+issue: 62
+state_path: .codex/pm/issue-state/62-cut-the-first-harnesshub-mvp-release-candidate.md
+---
+
+## Context
+
+Prepare the first HarnessHub MVP release candidate around the current OpenClaw-first image lifecycle.
+
+The repository is close to MVP-complete in capability, but there is not yet a concrete release cut with notes and a stable acceptance path.
+
+## Deliverable
+
+Prepare the first HarnessHub MVP release candidate around the current OpenClaw-first image lifecycle.
+
+## Scope
+
+- define the first MVP release candidate version framing
+- add release notes or release-candidate documentation scoped to the current MVP
+- document one clean acceptance path for a fresh operator
+
+## Acceptance Criteria
+
+- the repository contains one explicit MVP release-candidate document or noteset
+- the release framing is consistent with the current MVP scope and non-goals
+- a fresh reader can understand what is in the first MVP release and how to validate it
+
+## Validation
+
+-
+
+## Implementation Notes

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ For the current product framing, see:
 - `docs/prds/0003-roadmap-mvp-to-v1.md`
 - `docs/architecture/0001-harness-image-architecture.md`
 - `docs/releases/0001-mvp-exit-criteria.md`
+- `docs/releases/0002-mvp-release-candidate.md`
 
 ## Why
 

--- a/docs/releases/0001-mvp-exit-criteria.md
+++ b/docs/releases/0001-mvp-exit-criteria.md
@@ -101,3 +101,5 @@ HarnessHub should be treated as MVP-complete when:
 3. any remaining open work fits under accepted MVP limitations rather than MVP blockers
 
 At that point, the next step is not more MVP-definition work. The next step is to cut and document the first MVP release candidate.
+
+The current release-candidate framing for that cut is documented in [0002-mvp-release-candidate.md](./0002-mvp-release-candidate.md).

--- a/docs/releases/0002-mvp-release-candidate.md
+++ b/docs/releases/0002-mvp-release-candidate.md
@@ -1,0 +1,105 @@
+# HarnessHub MVP Release Candidate 1
+
+## Status
+
+Current release-candidate framing for the first HarnessHub MVP cut.
+
+This document packages the current OpenClaw-first MVP into one concrete release candidate instead of leaving release readiness implicit across multiple docs.
+
+## Version Framing
+
+The first HarnessHub MVP release candidate is framed as:
+
+- proposed version: `v0.2.0-rc.1`
+- release shape: local CLI plus documented image contract
+- first production-grade adapter: OpenClaw
+
+This framing keeps the old `v0.1` as the historical seed release while making the current MVP a clearly separate release line.
+
+## What This Release Candidate Includes
+
+- the `harness` CLI with `inspect`, `export`, `import`, and `verify`
+- one canonical `.harness` archive format
+- explicit manifest, pack-type, placement, rebinding, and readiness semantics
+- two export modes: `template` and `instance`
+- inspect-to-export workflow guidance
+- verify readiness classes with remediation guidance
+- a formal MVP image specification
+- a committed OpenClaw validation baseline with regression assertions
+- repository-local harness guardrails for issue-scoped delivery
+
+## What This Release Candidate Does Not Include
+
+- a second runtime adapter
+- parent-image activation or layer composition
+- registry or catalog primitives
+- cryptographic signing
+- hosted UI or SaaS platform behavior
+
+Those remain post-MVP or 1.0 concerns and must not block this release candidate.
+
+## Fresh Operator Acceptance Path
+
+A fresh operator should be able to validate the current release candidate with this path:
+
+```bash
+npm install
+npm run build
+
+harness inspect -p /path/to/openclaw
+harness export -p /path/to/openclaw -t template -o my-agent.harness
+harness import my-agent.harness -t /tmp/harnesshub-import
+harness verify -p /tmp/harnesshub-import
+```
+
+For a migration-oriented source, the inspect output should instead recommend:
+
+```bash
+harness export -p /path/to/openclaw -t instance -o my-agent.harness
+```
+
+If the operator intentionally wants a share-oriented template despite an `instance` recommendation, the explicit override path is:
+
+```bash
+harness export -p /path/to/openclaw -t template --allow-pack-type-override -o my-agent.harness
+```
+
+## Release Validation Commands
+
+The candidate branch should pass:
+
+```bash
+npm run build
+npm test
+./scripts/run-agent-preflight.sh
+./scripts/run-cli-smoke.sh
+./scripts/run-openclaw-e2e-validation.sh
+```
+
+These commands jointly validate:
+
+- source build correctness
+- unit and integration coverage
+- repository harness guardrails
+- documented CLI path behavior
+- real local OpenClaw end-to-end packaging behavior
+
+## Release Notes Summary
+
+This MVP release candidate marks the point where HarnessHub is no longer just an OpenClaw packaging experiment.
+
+It now has:
+
+- an explicit product boundary
+- an explicit image contract
+- explicit pack-type policy
+- explicit readiness semantics
+- a real validation artifact and regression baseline
+
+That is enough to treat the current build as a release candidate for the OpenClaw-first MVP.
+
+## References
+
+- `docs/releases/0001-mvp-exit-criteria.md`
+- `docs/specs/0001-mvp-harness-image-specification.md`
+- `docs/validation/openclaw-e2e-validation.md`


### PR DESCRIPTION
Closes #62

Prepare the first HarnessHub MVP release candidate around the current OpenClaw-first image lifecycle.

Validation:
- `./scripts/run-agent-preflight.sh`