### PR TITLE
Close local issue-state drift when issue tasks are marked done

### DIFF
--- a/.codex/pm/issue-state/60-define-mvp-exit-criteria-and-release-checklist.md
+++ b/.codex/pm/issue-state/60-define-mvp-exit-criteria-and-release-checklist.md
@@ -3,7 +3,7 @@ type: issue_state
 issue: 60
 task: .codex/pm/tasks/product-direction/define-mvp-exit-criteria-and-release-checklist.md
 title: Define MVP exit criteria and release checklist
-status: in_progress
+status: done
 ---
 
 ## Summary
@@ -20,14 +20,13 @@ HarnessHub now has the core image lifecycle and contract in place, but there is 
 
 ## Open Questions
 
--
+- 
 
 ## Next Steps
 
-- add one MVP exit document with concrete release gates
-- define the required local validation commands and expected outcomes
-- record the known acceptable MVP limitations so 1.0 work does not block MVP release
+- use the checklist as the release gate for future MVP acceptance review
 
 ## Artifacts
 
--
+- docs/releases/0001-mvp-exit-criteria.md
+- merged in PR #63

--- a/.codex/pm/issue-state/61-add-remediation-guidance-to-verify-readiness-output.md
+++ b/.codex/pm/issue-state/61-add-remediation-guidance-to-verify-readiness-output.md
@@ -3,7 +3,7 @@ type: issue_state
 issue: 61
 task: .codex/pm/tasks/product-direction/add-remediation-guidance-to-verify-readiness-output.md
 title: Add remediation guidance to verify readiness output
-status: in_progress
+status: done
 ---
 
 ## Summary
@@ -20,14 +20,12 @@ HarnessHub now reports explicit readiness classes, but operators still need to i
 
 ## Open Questions
 
--
+- 
 
 ## Next Steps
 
-- define stable remediation guidance for current verify failure and follow-up cases
-- surface the guidance in text and JSON verify output
-- keep the guidance within current MVP scope without introducing a policy engine
+- keep future readiness classes aligned with stable remediation wording in text and JSON output
 
 ## Artifacts
 
--
+- merged in PR #64

--- a/.codex/pm/issue-state/62-cut-the-first-harnesshub-mvp-release-candidate.md
+++ b/.codex/pm/issue-state/62-cut-the-first-harnesshub-mvp-release-candidate.md
@@ -3,7 +3,7 @@ type: issue_state
 issue: 62
 task: .codex/pm/tasks/product-direction/cut-the-first-harnesshub-mvp-release-candidate.md
 title: Cut the first HarnessHub MVP release candidate
-status: backlog
+status: done
 ---
 
 ## Summary
@@ -20,14 +20,13 @@ The repository is close to MVP-complete in capability, but there is not yet a co
 
 ## Open Questions
 
--
+- 
 
 ## Next Steps
 
-- define the first MVP release candidate version framing
-- add release notes or release-candidate documentation scoped to the current MVP
-- document one clean acceptance path for a fresh operator
+- use the release-candidate framing as the baseline for fresh-operator acceptance and follow-on release work
 
 ## Artifacts
 
--
+- docs/releases/0002-mvp-release-candidate.md
+- merged in PR #66

--- a/.codex/pm/issue-state/67-codify-harnesshub-as-environment-capability-packaging-not-agent-packaging.md
+++ b/.codex/pm/issue-state/67-codify-harnesshub-as-environment-capability-packaging-not-agent-packaging.md
@@ -3,7 +3,7 @@ type: issue_state
 issue: 67
 task: .codex/pm/tasks/product-direction/codify-harnesshub-as-environment-capability-packaging-not-agent-packaging.md
 title: Codify HarnessHub as environment capability packaging, not agent packaging
-status: backlog
+status: done
 ---
 
 ## Summary
@@ -20,14 +20,13 @@ Current docs define harness versus runtime, but they do not yet explicitly answe
 
 ## Open Questions
 
--
+- 
 
 ## Next Steps
 
-- add one direction memo under docs/architecture/
-- explain the decision with concrete OpenClaw, Codex, and Claude Code examples
-- document direct implications for harness identity, layering, and runtime adapters
+- cite the memo as the canonical product-boundary reference in future architecture and roadmap work
 
 ## Artifacts
 
--
+- docs/architecture/0002-harness-capability-packaging.md
+- merged in PR #68

--- a/.codex/pm/issue-state/69-close-local-issue-state-drift-when-issue-tasks-are-marked-done.md
+++ b/.codex/pm/issue-state/69-close-local-issue-state-drift-when-issue-tasks-are-marked-done.md
@@ -1,0 +1,43 @@
+---
+type: issue_state
+issue: 69
+task: .codex/pm/tasks/repository-harness/close-local-issue-state-drift-when-issue-tasks-are-marked-done.md
+title: Close local issue-state drift when issue tasks are marked done
+status: done
+---
+
+## Summary
+
+Close the local harness gap where PR/task closure sync enforces `.codex/pm/tasks/*` status but leaves `.codex/pm/issue-state/*` stale.
+
+Recent merged issues `#60`, `#61`, `#62`, and `#67` reached `task.status=done` and were merged into `upstream/main`, but their local `issue-state` docs still showed `in_progress` or `backlog`.
+
+The current harness already blocks pushes when a PR closes an issue but the matching task file is not marked `done`. It does **not**:
+
+- update the matching `issue-state` status when `set-status ... done` is called
+- fail closure sync when the matching `issue-state` status disagrees with the task
+- provide a repo-local command to finalize both task and issue-state together
+
+That leaves the local PM model internally inconsistent even when the guarded PR flow succeeds.
+
+## Validated Facts
+
+- marking an issue task done cannot leave a linked issue-state document at `backlog` or `in_progress`
+- closure sync or another repo-local guardrail fails when task and issue-state status disagree for a closing issue
+- regression tests cover the stale issue-state case
+- contributor guidance reflects the intended finalize flow
+
+## Open Questions
+
+-
+
+## Next Steps
+
+- decide the smallest reliable place to enforce task and issue-state status coherence
+- add a guardrail so closing an issue cannot leave a stale issue-state status behind
+- add regression coverage for the drift case
+- update workflow guidance if the operator-facing command changes
+
+## Artifacts
+
+-

--- a/.codex/pm/tasks/repository-harness/close-local-issue-state-drift-when-issue-tasks-are-marked-done.md
+++ b/.codex/pm/tasks/repository-harness/close-local-issue-state-drift-when-issue-tasks-are-marked-done.md
@@ -1,0 +1,49 @@
+---
+type: task
+epic: repository-harness
+slug: close-local-issue-state-drift-when-issue-tasks-are-marked-done
+title: Close local issue-state drift when issue tasks are marked done
+status: done
+task_type: implementation
+labels: bug,harness,test
+issue: 69
+state_path: .codex/pm/issue-state/69-close-local-issue-state-drift-when-issue-tasks-are-marked-done.md
+---
+
+## Context
+
+Close the local harness gap where PR/task closure sync enforces `.codex/pm/tasks/*` status but leaves `.codex/pm/issue-state/*` stale.
+
+Recent merged issues `#60`, `#61`, `#62`, and `#67` reached `task.status=done` and were merged into `upstream/main`, but their local `issue-state` docs still showed `in_progress` or `backlog`.
+
+The current harness already blocks pushes when a PR closes an issue but the matching task file is not marked `done`. It does **not**:
+
+- update the matching `issue-state` status when `set-status ... done` is called
+- fail closure sync when the matching `issue-state` status disagrees with the task
+- provide a repo-local command to finalize both task and issue-state together
+
+That leaves the local PM model internally inconsistent even when the guarded PR flow succeeds.
+
+## Deliverable
+
+Close the local harness gap where PR/task closure sync enforces `.codex/pm/tasks/*` status but leaves `.codex/pm/issue-state/*` stale.
+
+## Scope
+
+- decide the smallest reliable place to enforce task and issue-state status coherence
+- add a guardrail so closing an issue cannot leave a stale issue-state status behind
+- add regression coverage for the drift case
+- update workflow guidance if the operator-facing command changes
+
+## Acceptance Criteria
+
+- marking an issue task done cannot leave a linked issue-state document at `backlog` or `in_progress`
+- closure sync or another repo-local guardrail fails when task and issue-state status disagree for a closing issue
+- regression tests cover the stale issue-state case
+- contributor guidance reflects the intended finalize flow
+
+## Validation
+
+-
+
+## Implementation Notes

--- a/docs/engineering/repository-governance.md
+++ b/docs/engineering/repository-governance.md
@@ -36,10 +36,11 @@ node scripts/codex-pm.mjs init
 node scripts/codex-pm.mjs task-new <epic> <slug> --title "<title>" --issue <n>
 node scripts/codex-pm.mjs set-status <task-path> in_progress
 node scripts/codex-pm.mjs issue-state-init <task-path>
+node scripts/codex-pm.mjs set-status <task-path> done
 node scripts/codex-pm.mjs pr-body <task-path> --issue <n>
 ```
 
-The task file is the local twin of the GitHub issue. For longer work, the issue-state file holds validated facts, open questions, next steps, and artifacts so later sessions do not need to reconstruct them.
+The task file is the local twin of the GitHub issue. For longer work, the issue-state file holds validated facts, open questions, next steps, and artifacts so later sessions do not need to reconstruct them. When a task already has an issue-state document, `set-status` keeps the linked issue-state status in sync so closure checks cannot land with stale local state.
 
 ## Review And Preflight
 
@@ -61,7 +62,7 @@ Preflight checks:
 
 - branch freshness against `upstream/main`
 - review note and proof coherence
-- issue-state readiness
+- issue-state readiness and task/status coherence
 - build and test execution
 - local PR closure sync when the current PR body is available through `gh`
 

--- a/scripts/codex-pm.mjs
+++ b/scripts/codex-pm.mjs
@@ -186,13 +186,7 @@ function setStatus(args, io) {
   requireValue(status, "status is required");
   validateEnum(status, VALID_STATUSES, "status");
   const document = readDocument(filePath);
-  document.metadata.status = status;
-  if (options.reason) {
-    document.metadata.status_reason = options.reason;
-  } else {
-    delete document.metadata.status_reason;
-  }
-  persistDocument(document);
+  updateDocumentStatus(document, status, options.reason);
   io.log(document.path);
   return 0;
 }
@@ -203,9 +197,7 @@ function blocked(args, io) {
   requireValue(filePath, "path is required");
   requireValue(options.reason, "--reason is required");
   const document = readDocument(filePath);
-  document.metadata.status = "blocked";
-  document.metadata.status_reason = options.reason;
-  persistDocument(document);
+  updateDocumentStatus(document, "blocked", options.reason);
   io.log(document.path);
   return 0;
 }
@@ -457,6 +449,17 @@ export function docToDict(document) {
   };
 }
 
+function updateDocumentStatus(document, status, reason) {
+  document.metadata.status = status;
+  if (reason) {
+    document.metadata.status_reason = reason;
+  } else {
+    delete document.metadata.status_reason;
+  }
+  persistDocument(document);
+  syncLinkedIssueStateStatus(document);
+}
+
 function issueStatePath(document) {
   const issue = parseIssueNumber(document.metadata.issue ?? "");
   if (issue === null) throw new Error(`task has no numeric issue reference: ${document.path}`);
@@ -494,6 +497,14 @@ function loadIssueState(taskDocument) {
   return null;
 }
 
+function syncLinkedIssueStateStatus(taskDocument) {
+  if ((taskDocument.metadata.type ?? "") !== "task") return;
+  const stateDocument = loadIssueState(taskDocument);
+  if (!stateDocument) return;
+  stateDocument.metadata.status = taskDocument.metadata.status ?? "";
+  persistDocument(stateDocument);
+}
+
 function checkIssueState(branch) {
   const issue = parseIssueFromBranch(branch);
   if (issue === null) return null;
@@ -509,6 +520,12 @@ function checkIssueState(branch) {
     return {
       ok: false,
       message: `Issue state check failed: in-progress issue has no state document. Run \`node scripts/codex-pm.mjs issue-state-init ${task.path}\`.`,
+    };
+  }
+  if ((stateDocument.metadata.status ?? "") !== (task.metadata.status ?? "")) {
+    return {
+      ok: false,
+      message: `Issue state check failed: task and issue-state status differ for issue #${issue}. Task=${task.metadata.status ?? ""} issue-state=${stateDocument.metadata.status ?? ""}.`,
     };
   }
   return { ok: true, message: `Issue state check passed: ${stateDocument.path}` };
@@ -619,6 +636,14 @@ export function verifyClosureSync(prBody, changedFiles) {
     }
     if (!matching.some((document) => document.metadata.status === "done")) {
       errors.push(`PR closes #${issue} but matching task file is not marked done: ${matching.map((doc) => doc.path).join(", ")}`);
+      continue;
+    }
+    for (const document of matching) {
+      const stateDocument = loadIssueState(document);
+      if (!stateDocument) continue;
+      if ((stateDocument.metadata.status ?? "") !== (document.metadata.status ?? "")) {
+        errors.push(`PR closes #${issue} but linked issue-state status does not match task status: ${stateDocument.path} is ${stateDocument.metadata.status ?? ""}, task is ${document.metadata.status ?? ""}.`);
+      }
     }
   }
   return errors;

--- a/test/codex-pm.test.ts
+++ b/test/codex-pm.test.ts
@@ -84,6 +84,73 @@ describe("codex-pm", () => {
     ])).toBe(0);
   });
 
+  it("syncs linked issue-state status when task status changes", () => {
+    expect(main(["init"])).toBe(0);
+    expect(main([
+      "task-new",
+      "repository-harness",
+      "bootstrap",
+      "--title",
+      "Bootstrap harness",
+      "--issue",
+      "42",
+    ])).toBe(0);
+    const taskPath = path.join(tmpDir, ".codex", "pm", "tasks", "repository-harness", "bootstrap.md");
+
+    expect(main(["issue-state-init", taskPath])).toBe(0);
+    expect(main(["set-status", taskPath, "in_progress"])).toBe(0);
+    expect(main(["set-status", taskPath, "done"])).toBe(0);
+
+    const statePath = path.join(tmpDir, ".codex", "pm", "issue-state", "42-bootstrap.md");
+    const stateDocument = fs.readFileSync(statePath, "utf8");
+    expect(stateDocument).toContain("status: done");
+  });
+
+  it("fails issue-state check and closure sync when linked issue-state status drifts", () => {
+    expect(main(["init"])).toBe(0);
+    expect(main([
+      "task-new",
+      "repository-harness",
+      "bootstrap",
+      "--title",
+      "Bootstrap harness",
+      "--issue",
+      "42",
+    ])).toBe(0);
+    const taskPath = path.join(tmpDir, ".codex", "pm", "tasks", "repository-harness", "bootstrap.md");
+
+    expect(main(["issue-state-init", taskPath])).toBe(0);
+    expect(main(["set-status", taskPath, "in_progress"])).toBe(0);
+
+    const statePath = path.join(tmpDir, ".codex", "pm", "issue-state", "42-bootstrap.md");
+    const driftedState = fs.readFileSync(statePath, "utf8").replace("status: in_progress", "status: backlog");
+    fs.writeFileSync(statePath, driftedState, "utf8");
+
+    const errors: string[] = [];
+    expect(main(["issue-state-check", "--branch", "issue-42-bootstrap"], {
+      log: () => undefined,
+      error: (value: string) => errors.push(value),
+    } as Console)).toBe(1);
+    expect(errors.join("\n")).toContain("task and issue-state status differ");
+
+    expect(main(["set-status", taskPath, "done"])).toBe(0);
+    const redriftedState = fs.readFileSync(statePath, "utf8").replace("status: done", "status: backlog");
+    fs.writeFileSync(statePath, redriftedState, "utf8");
+
+    const closureErrors: string[] = [];
+    expect(main([
+      "verify-pr-closure-sync",
+      "--pr-body",
+      "Closes #42",
+      "--changed-file",
+      path.relative(tmpDir, taskPath),
+    ], {
+      log: () => undefined,
+      error: (value: string) => closureErrors.push(value),
+    } as Console)).toBe(1);
+    expect(closureErrors.join("\n")).toContain("linked issue-state status does not match task status");
+  });
+
   it("hydrates task twins and issue state from issue intent", () => {
     expect(main(["init"])).toBe(0);
     const issueBodyPath = path.join(tmpDir, "issue-body.md");

--- a/test/pre-push-hook.test.ts
+++ b/test/pre-push-hook.test.ts
@@ -25,6 +25,7 @@ function prepareRepo() {
 
   fs.mkdirSync(path.join(repo, ".githooks"), { recursive: true });
   fs.mkdirSync(path.join(repo, "scripts"), { recursive: true });
+  fs.mkdirSync(path.join(repo, ".codex", "pm", "issue-state"), { recursive: true });
   fs.copyFileSync(path.join(sourceRoot, ".githooks", "pre-push"), path.join(repo, ".githooks", "pre-push"));
   fs.copyFileSync(path.join(sourceRoot, "scripts", "codex-pm.mjs"), path.join(repo, "scripts", "codex-pm.mjs"));
   fs.chmodSync(path.join(repo, ".githooks", "pre-push"), 0o755);
@@ -203,6 +204,61 @@ exit 1
 
     expect(result.status).toBe(1);
     expect(result.stdout).toContain("already has a merged PR");
+    fs.rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("blocks closure sync when linked issue-state status drifts", () => {
+    const { repo, binDir } = prepareRepo();
+    const taskPath = path.join(repo, ".codex", "pm", "tasks", "repository-harness", "bootstrap.md");
+    const statePath = path.join(repo, ".codex", "pm", "issue-state", "42-bootstrap.md");
+
+    fs.writeFileSync(statePath, `---
+type: issue_state
+issue: 42
+task: .codex/pm/tasks/repository-harness/bootstrap.md
+title: Bootstrap harness
+status: backlog
+---
+
+## Summary
+
+Test state.
+
+## Validated Facts
+
+- local task and issue-state drift
+
+## Open Questions
+
+- 
+
+## Next Steps
+
+- sync status
+
+## Artifacts
+
+- 
+`, "utf8");
+
+    const taskText = fs.readFileSync(taskPath, "utf8")
+      .replace("status: in_progress", "status: done")
+      .replace("issue: 42", "issue: 42\nstate_path: .codex/pm/issue-state/42-bootstrap.md");
+    fs.writeFileSync(taskPath, taskText, "utf8");
+
+    const result = spawnSync(path.join(repo, ".githooks", "pre-push"), [], {
+      cwd: repo,
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH}`,
+        BYPASS_BRANCH_FRESHNESS_CHECK: "1",
+        HARNESSHUB_BASE_REF: "main",
+      },
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("linked issue-state status does not match task status");
     fs.rmSync(repo, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
Closes #69

Close the local harness gap where PR/task closure sync enforces `.codex/pm/tasks/*` status but leaves `.codex/pm/issue-state/*` stale.

Validation:
- `npm test`