### PR TITLE
Make export and verify lineage-aware for composed v0.2.0 images

### DIFF
--- a/.codex/pm/issue-state/109-make-export-and-verify-lineage-aware-for-composed-v0-2-0-images.md
+++ b/.codex/pm/issue-state/109-make-export-and-verify-lineage-aware-for-composed-v0-2-0-images.md
@@ -3,8 +3,8 @@ type: issue_state
 issue: 109
 task: .codex/pm/tasks/product-direction/make-export-and-verify-lineage-aware-for-composed-v0-2-0-images.md
 title: Make export and verify lineage-aware for composed v0.2.0 images
-status: in_progress
-delivery_stage: implementing
+status: done
+delivery_stage: ready_to_deliver
 ---
 
 ## Summary

--- a/.codex/pm/issue-state/109-make-export-and-verify-lineage-aware-for-composed-v0-2-0-images.md
+++ b/.codex/pm/issue-state/109-make-export-and-verify-lineage-aware-for-composed-v0-2-0-images.md
@@ -4,7 +4,8 @@ issue: 109
 task: .codex/pm/tasks/product-direction/make-export-and-verify-lineage-aware-for-composed-v0-2-0-images.md
 title: Make export and verify lineage-aware for composed v0.2.0 images
 status: done
-delivery_stage: ready_to_deliver
+delivery_stage: pr_opened
+pr_url: https://github.com/HarnessHub/HarnessHub/pull/116
 ---
 
 ## Summary

--- a/.codex/pm/issue-state/109-make-export-and-verify-lineage-aware-for-composed-v0-2-0-images.md
+++ b/.codex/pm/issue-state/109-make-export-and-verify-lineage-aware-for-composed-v0-2-0-images.md
@@ -1,0 +1,42 @@
+---
+type: issue_state
+issue: 109
+task: .codex/pm/tasks/product-direction/make-export-and-verify-lineage-aware-for-composed-v0-2-0-images.md
+title: Make export and verify lineage-aware for composed v0.2.0 images
+status: in_progress
+delivery_stage: implementing
+---
+
+## Summary
+
+Extend the existing export/import/verify lifecycle so it understands the first composed-image semantics introduced in v0.2.0.
+
+## Validated Facts
+
+- export works for the supported v0.2.0 composed flow
+- import remains backward compatible with existing v0.1.x images
+- verify distinguishes lineage-aware success from lineage declaration/materialization failures
+- tests cover single-image compatibility and composed-image verification cases
+- composed outputs now persist a resolved definition snapshot with an image-id parent reference
+- export can recover lineage from a composed source path even when the caller is outside the original definition repo
+- verify can validate lineage semantics from either a pack manifest or a local definition snapshot
+
+## Open Questions
+
+-
+
+## Next Steps
+
+- commit, review-checkpoint, preflight, and deliver the branch
+- after merge, continue with `#108`
+
+## Artifacts
+
+- `src/core/compose.ts`
+- `src/core/packer.ts`
+- `src/core/verifier.ts`
+- `src/commands/verify.ts`
+- `docs/specs/0003-v0-2-0-local-compose-materialization.md`
+- `test/e2e.test.ts`
+- `test/cli-integration.test.ts`
+- `test/command-entrypoints.test.ts`

--- a/.codex/pm/tasks/product-direction/make-export-and-verify-lineage-aware-for-composed-v0-2-0-images.md
+++ b/.codex/pm/tasks/product-direction/make-export-and-verify-lineage-aware-for-composed-v0-2-0-images.md
@@ -1,0 +1,45 @@
+---
+type: task
+epic: product-direction
+slug: make-export-and-verify-lineage-aware-for-composed-v0-2-0-images
+title: Make export and verify lineage-aware for composed v0.2.0 images
+status: in_progress
+task_type: implementation
+issue: 109
+state_path: .codex/pm/issue-state/109-make-export-and-verify-lineage-aware-for-composed-v0-2-0-images.md
+---
+
+## Context
+
+Extend the existing export/import/verify lifecycle so it understands the first composed-image semantics introduced in v0.2.0.
+
+## Deliverable
+
+Extend the existing export/import/verify lifecycle so it understands the first composed-image semantics introduced in v0.2.0.
+
+## Scope
+
+- allow export to operate on definition/composed local results, not only raw runtime snapshots
+- keep import behavior compatible with v0.1.x images
+- make verify check operational lineage semantics instead of only field presence
+- report parent reference, layer ordering, and composed materialization expectations clearly
+
+## Acceptance Criteria
+
+- export works for the supported v0.2.0 composed flow
+- import remains backward compatible with existing v0.1.x images
+- verify distinguishes lineage-aware success from lineage declaration/materialization failures
+- tests cover single-image compatibility and composed-image verification cases
+
+## Validation
+
+- `npm run build`
+- `npm test`
+- `./scripts/run-cli-smoke.sh`
+
+## Implementation Notes
+
+- compose now persists a resolved `harness.definition.json` snapshot into the materialized output so later lifecycle steps can recover lineage semantics without the original repo-relative parent path
+- export now auto-discovers a definition snapshot from the source path when no explicit or cwd definition is present
+- verify now consumes optional definition metadata in addition to pack manifests and reports `definition_contract`, `lineage_declaration`, and `lineage_materialization` checks
+- added regression coverage for composed export discovery, lineage-aware verify success, lineage materialization failure, and invalid lineage declaration handling

--- a/.codex/pm/tasks/product-direction/make-export-and-verify-lineage-aware-for-composed-v0-2-0-images.md
+++ b/.codex/pm/tasks/product-direction/make-export-and-verify-lineage-aware-for-composed-v0-2-0-images.md
@@ -3,7 +3,7 @@ type: task
 epic: product-direction
 slug: make-export-and-verify-lineage-aware-for-composed-v0-2-0-images
 title: Make export and verify lineage-aware for composed v0.2.0 images
-status: in_progress
+status: done
 task_type: implementation
 issue: 109
 state_path: .codex/pm/issue-state/109-make-export-and-verify-lineage-aware-for-composed-v0-2-0-images.md

--- a/docs/specs/0003-v0-2-0-local-compose-materialization.md
+++ b/docs/specs/0003-v0-2-0-local-compose-materialization.md
@@ -71,6 +71,7 @@ The output directory is a local OpenClaw-style materialization suitable for:
 - manual inspection of the composed result
 
 After compose, workspace paths in the output config are rebound to the materialized output directory.
+The output also persists a local `harness.definition.json` snapshot with the resolved parent image id so later export and verify flows can recover lineage semantics without depending on the original repo path layout.
 
 ## Non-Goals
 

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import { verify } from "../core/verifier.js";
 import { printVerifyResult } from "../utils/output.js";
 import { openClawAdapter } from "../core/adapters/openclaw.js";
-import type { Manifest, OutputFormat } from "../core/types.js";
+import { HARNESS_DEFINITION_FILE, type Manifest, type OutputFormat } from "../core/types.js";
 
 export const verifyCommand = new Command("verify")
   .description("Verify an imported OpenClaw instance is structurally complete")
@@ -28,7 +28,13 @@ export const verifyCommand = new Command("verify")
         }
       }
 
-      const result = verify(targetDir, manifest);
+      let definition: unknown;
+      const definitionPath = path.join(targetDir, HARNESS_DEFINITION_FILE);
+      if (fs.existsSync(definitionPath)) {
+        definition = JSON.parse(fs.readFileSync(definitionPath, "utf-8"));
+      }
+
+      const result = verify(targetDir, manifest, definition);
       printVerifyResult(result as unknown as Record<string, unknown>, format);
 
       if (!result.valid) {

--- a/src/core/compose.ts
+++ b/src/core/compose.ts
@@ -5,6 +5,7 @@ import { openClawAdapter } from "./adapters/openclaw.js";
 import { readHarnessDefinition, validateOperationalDefinitionLineage } from "./definition.js";
 import {
   HARNESS_DEFINITION_FILE,
+  HARNESS_DEFINITION_SCHEMA_VERSION,
   type HarnessDefinition,
   type OutputFormat,
   type WorkspaceBinding,
@@ -95,6 +96,7 @@ export function composeHarness(options: ComposeOptions): ComposeResult {
   copyEntries(parent.entries, targetDir);
   copyEntries(child.entries, targetDir);
   const warnings = rebindComposedConfig(targetDir, child.workspaceBindings);
+  writeComposedDefinitionSnapshot(targetDir, definition, resolveParentImageId(definition, parentDir));
 
   return {
     definitionFile,
@@ -196,6 +198,25 @@ function resolveParentImageId(definition: HarnessDefinition, parentDir: string):
     return readHarnessDefinition(parentDefinitionFile).image.imageId;
   }
   return path.basename(parentDir);
+}
+
+function writeComposedDefinitionSnapshot(
+  targetDir: string,
+  definition: HarnessDefinition,
+  parentImageId: string
+) {
+  const snapshot: HarnessDefinition = {
+    ...definition,
+    schemaVersion: HARNESS_DEFINITION_SCHEMA_VERSION,
+    lineage: {
+      parentImage: {
+        refType: "image-id",
+        value: parentImageId,
+      },
+      layerOrder: [parentImageId, definition.image.imageId],
+    },
+  };
+  fs.writeFileSync(path.join(targetDir, HARNESS_DEFINITION_FILE), `${JSON.stringify(snapshot, null, 2)}\n`);
 }
 
 function collectComposeSource(stateDir: string): ComposeSource {

--- a/src/core/packer.ts
+++ b/src/core/packer.ts
@@ -532,7 +532,18 @@ function resolveDefinitionFile(options: ExportOptions): string | null {
   }
 
   const implicitDefinition = path.resolve(options.cwd ?? process.cwd(), "harness.definition.json");
-  return fs.existsSync(implicitDefinition) ? implicitDefinition : null;
+  if (fs.existsSync(implicitDefinition)) {
+    return implicitDefinition;
+  }
+
+  if (options.sourcePath) {
+    const sourceDefinition = path.resolve(openClawAdapter.resolveStateDir(options.sourcePath), "harness.definition.json");
+    if (fs.existsSync(sourceDefinition)) {
+      return sourceDefinition;
+    }
+  }
+
+  return null;
 }
 
 function resolveExportLineage(params: {

--- a/src/core/verifier.ts
+++ b/src/core/verifier.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
 import JSON5 from "json5";
-import type { Manifest, VerifyResult, VerifyCheck, ReadinessClass } from "./types.js";
+import { validateHarnessDefinition, validateOperationalDefinitionLineage } from "./definition.js";
+import type { HarnessComponent, HarnessDefinition, Manifest, VerifyResult, VerifyCheck, ReadinessClass } from "./types.js";
 import { SCHEMA_VERSION } from "./types.js";
 import { openClawAdapter } from "./adapters/openclaw.js";
 import { validateManifestContract } from "./manifest.js";
@@ -9,13 +10,14 @@ import { validatePackTypeComponents } from "./pack-contract.js";
 
 const REQUIRED_WORKSPACE_FILES = ["AGENTS.md"];
 
-export function verify(targetDir: string, manifest?: Manifest): VerifyResult {
+export function verify(targetDir: string, manifest?: Manifest, definition?: unknown): VerifyResult {
   const checks: VerifyCheck[] = [];
   const warnings: string[] = [];
   const errors: string[] = [];
   const runtimeReadinessIssues: string[] = [];
   const manifestWorkspaces = manifest?.workspaces ?? [];
   const manifestBindingRules = manifest?.bindings?.workspaces ?? [];
+  const parsedDefinition = definition as HarnessDefinition | undefined;
 
   // Check 1: Target directory exists
   const dirExists = fs.existsSync(targetDir);
@@ -358,6 +360,57 @@ export function verify(targetDir: string, manifest?: Manifest): VerifyResult {
     }
   }
 
+  if (definition !== undefined) {
+    const definitionErrors = validateHarnessDefinition(definition);
+    const operationalDefinitionErrors = definitionErrors.length === 0
+      ? validateOperationalDefinitionLineage(definition as HarnessDefinition)
+      : [];
+    const allDefinitionErrors = [...definitionErrors, ...operationalDefinitionErrors];
+    checks.push({
+      name: "definition_contract",
+      passed: allDefinitionErrors.length === 0,
+      message: allDefinitionErrors.length === 0
+        ? "Definition contract is valid"
+        : allDefinitionErrors.join("; "),
+    });
+    if (allDefinitionErrors.length > 0) {
+      errors.push(...allDefinitionErrors.map((error) => `Definition contract error: ${error}`));
+      runtimeReadinessIssues.push(...allDefinitionErrors.map((error) => `Definition contract error: ${error}`));
+      return finalizeVerifyResult(checks, warnings, errors, runtimeReadinessIssues);
+    }
+  }
+
+  const lineageMetadata = resolveLineageMetadata(manifest, parsedDefinition);
+  if (lineageMetadata) {
+    const declarationErrors = validateLineageDeclaration(lineageMetadata.parentImageId, lineageMetadata.layerOrder, lineageMetadata.childImageId);
+    checks.push({
+      name: "lineage_declaration",
+      passed: declarationErrors.length === 0,
+      message: declarationErrors.length === 0
+        ? `Lineage declaration ${lineageMetadata.parentImageId ?? "root"} -> ${lineageMetadata.childImageId}`
+        : declarationErrors.join("; "),
+    });
+    if (declarationErrors.length > 0) {
+      errors.push(...declarationErrors.map((error) => `Lineage declaration error: ${error}`));
+      runtimeReadinessIssues.push(...declarationErrors.map((error) => `Lineage declaration error: ${error}`));
+      return finalizeVerifyResult(checks, warnings, errors, runtimeReadinessIssues);
+    }
+
+    const expectedComponents = parsedDefinition?.verify.expectedComponents
+      ?? manifest?.harness?.components
+      ?? [];
+    const materializationFailures = validateLineageMaterialization(targetDir, expectedComponents);
+    checks.push({
+      name: "lineage_materialization",
+      passed: materializationFailures.length === 0,
+      message: materializationFailures.length === 0
+        ? `Lineage materialization validated for ${expectedComponents.length} expected components`
+        : materializationFailures.join("; "),
+    });
+    warnings.push(...materializationFailures);
+    runtimeReadinessIssues.push(...materializationFailures);
+  }
+
   // Check 8: Workspace files are readable
   if (hasWorkspace) {
     const wsFiles = workspaceDirs.flatMap((dir) => {
@@ -389,6 +442,90 @@ export function verify(targetDir: string, manifest?: Manifest): VerifyResult {
     c => c.passed || !["directory_exists", "workspace_exists"].includes(c.name)
   );
   return finalizeVerifyResult(checks, warnings, errors, runtimeReadinessIssues, valid);
+}
+
+function resolveLineageMetadata(
+  manifest: Manifest | undefined,
+  definition: HarnessDefinition | undefined
+): { parentImageId: string | null; childImageId: string; layerOrder: string[] } | null {
+  if (manifest) {
+    return {
+      parentImageId: manifest.lineage.parentImage?.imageId ?? null,
+      childImageId: manifest.image.imageId,
+      layerOrder: manifest.lineage.layerOrder,
+    };
+  }
+  if (definition) {
+    return {
+      parentImageId: definition.lineage.parentImage?.value ?? null,
+      childImageId: definition.image.imageId,
+      layerOrder: definition.lineage.layerOrder,
+    };
+  }
+  return null;
+}
+
+function validateLineageDeclaration(
+  parentImageId: string | null,
+  layerOrder: readonly string[],
+  childImageId: string
+): string[] {
+  const errors: string[] = [];
+  if (parentImageId === null) {
+    if (layerOrder.length !== 0) {
+      errors.push("Lineage layer order must be empty when no parent image is declared");
+    }
+    return errors;
+  }
+  if (layerOrder.length !== 2) {
+    errors.push("Lineage layer order must contain exactly two entries when a parent image is declared");
+    return errors;
+  }
+  if (layerOrder[0] !== parentImageId) {
+    errors.push("Lineage layer order must start with the declared parent image id");
+  }
+  if (layerOrder[1] !== childImageId) {
+    errors.push("Lineage layer order must end with the declared child image id");
+  }
+  return errors;
+}
+
+function validateLineageMaterialization(targetDir: string, expectedComponents: readonly HarnessComponent[]): string[] {
+  const failures: string[] = [];
+  for (const component of expectedComponents) {
+    switch (component) {
+      case "workspace":
+        if (!hasWorkspaceMaterialized(targetDir)) {
+          failures.push("Lineage materialization missing expected component: workspace");
+        }
+        break;
+      case "config":
+        if (openClawAdapter.findConfigFile(targetDir) === null) {
+          failures.push("Lineage materialization missing expected component: config");
+        }
+        break;
+      case "skills":
+        if (!hasSkillsMaterialized(targetDir)) {
+          failures.push("Lineage materialization missing expected component: skills");
+        }
+        break;
+      default:
+        break;
+    }
+  }
+  return failures;
+}
+
+function hasWorkspaceMaterialized(targetDir: string): boolean {
+  return fs.existsSync(path.join(targetDir, "workspace"))
+    || fs.readdirSync(targetDir, { withFileTypes: true }).some((entry) => entry.isDirectory() && entry.name.startsWith("workspace-"));
+}
+
+function hasSkillsMaterialized(targetDir: string): boolean {
+  const workspaceRoots = ["workspace", ...fs.readdirSync(targetDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name.startsWith("workspace-"))
+    .map((entry) => entry.name)];
+  return workspaceRoots.some((workspaceRoot) => fs.existsSync(path.join(targetDir, workspaceRoot, "skills")));
 }
 
 function finalizeVerifyResult(

--- a/test/cli-integration.test.ts
+++ b/test/cli-integration.test.ts
@@ -143,9 +143,33 @@ describe("harness CLI integration", () => {
     expect(data.success).toBe(true);
     expect(data.parentDir).toBe(parentDir);
     expect(fs.readFileSync(path.join(outputDir, "workspace", "AGENTS.md"), "utf8")).toContain("Child Agent");
+    expect(JSON.parse(fs.readFileSync(path.join(outputDir, "harness.definition.json"), "utf8")).lineage).toEqual({
+      parentImage: { refType: "image-id", value: "compose-parent" },
+      layerOrder: ["compose-parent", "child-agent"],
+    });
 
     const composedConfig = JSON.parse(fs.readFileSync(path.join(outputDir, "openclaw.json"), "utf8"));
     expect(composedConfig.agents.defaults.workspace).toBe(path.join(outputDir, "workspace"));
+  });
+
+  it("verifies a composed output using the local definition snapshot when no manifest is present", () => {
+    const repoDir = path.join(tmpDir, "verify-compose-repo");
+    const parentDir = path.join(tmpDir, "verify-compose-parent");
+    const childDir = path.join(tmpDir, "verify-compose-child");
+    const outputDir = path.join(tmpDir, "verify-compose-output");
+    fs.mkdirSync(repoDir, { recursive: true });
+    createTemplateSource(parentDir);
+    createTemplateSource(childDir);
+
+    expect(runCli(["init", "--image-id", "child-agent", "--parent-path", "../verify-compose-parent", "-f", "json"], repoDir).status).toBe(0);
+    expect(runCli(["compose", "-p", childDir, "-o", outputDir, "-f", "json"], repoDir).status).toBe(0);
+
+    const verifyResult = runCli(["verify", "-p", outputDir, "-f", "json"]);
+    expect(verifyResult.status).toBe(0);
+    const data = JSON.parse(verifyResult.stdout);
+    expect(data.valid).toBe(true);
+    expect(data.checks.some((check: { name: string; passed: boolean }) => check.name === "lineage_declaration" && check.passed)).toBe(true);
+    expect(data.checks.some((check: { name: string; passed: boolean }) => check.name === "lineage_materialization" && check.passed)).toBe(true);
   });
 
   it("inspects a valid instance through the CLI", () => {

--- a/test/command-entrypoints.test.ts
+++ b/test/command-entrypoints.test.ts
@@ -485,7 +485,7 @@ describe("command entrypoints", () => {
     await verifyCommand.parseAsync(["node", "verify"], { from: "node" });
 
     expect(resolveStateDir).toHaveBeenCalled();
-    expect(verify).toHaveBeenCalledWith("/tmp/openclaw", { packId: "pack-3" });
+    expect(verify).toHaveBeenCalledWith("/tmp/openclaw", { packId: "pack-3" }, undefined);
     expect(printVerifyResult).toHaveBeenCalledWith(expect.objectContaining({
       readinessClass: "runtime_ready",
     }), "text");
@@ -519,9 +519,9 @@ describe("command entrypoints", () => {
     const { verifyCommand } = await importFresh<typeof import("../src/commands/verify.js")>("../src/commands/verify.js");
     await verifyCommand.parseAsync(["node", "verify"], { from: "node" });
 
-    expect(existsSync).toHaveBeenCalledTimes(2);
+    expect(existsSync).toHaveBeenCalledTimes(3);
     expect(readFileSync).not.toHaveBeenCalled();
-    expect(verify).toHaveBeenCalledWith("/tmp/openclaw", undefined);
+    expect(verify).toHaveBeenCalledWith("/tmp/openclaw", undefined, undefined);
     expect(process.exitCode).toBe(1);
     expect(printVerifyResult).toHaveBeenCalledWith(expect.objectContaining({
       readinessClass: "manual_steps_required",
@@ -556,7 +556,65 @@ describe("command entrypoints", () => {
     await verifyCommand.parseAsync(["node", "verify"], { from: "node" });
 
     expect(readFileSync).toHaveBeenCalledOnce();
-    expect(verify).toHaveBeenCalledWith("/tmp/openclaw", { packId: "manifest-pack" });
+    expect(verify).toHaveBeenCalledWith("/tmp/openclaw", { packId: "manifest-pack" }, undefined);
+  });
+
+  it("loads a local definition snapshot when verify has no manifest candidates", async () => {
+    const existsSync = vi.fn((candidate: string) => candidate.endsWith("harness.definition.json"));
+    const readFileSync = vi.fn((candidate: string) => {
+      if (candidate.endsWith("harness.definition.json")) {
+        return JSON.stringify({
+          schemaVersion: "0.2.0",
+          kind: "harness-definition",
+          image: { imageId: "child-compose", adapter: "openclaw" },
+          lineage: {
+            parentImage: { refType: "image-id", value: "base-compose" },
+            layerOrder: ["base-compose", "child-compose"],
+          },
+          harness: {
+            intent: "agent-runtime-environment",
+            targetProduct: "openclaw",
+            components: ["config", "workspace", "skills"],
+          },
+          bindings: { workspaces: [] },
+          rebinding: { workspaceTargetMode: "absolute-path", mutableConfigTargets: [] },
+          source: { bootstrap: "starter", detectedProduct: null, configPath: null },
+          verify: {
+            readinessTarget: "runtime_ready",
+            expectedComponents: ["config", "workspace", "skills"],
+            requireWorkspaceBindings: true,
+          },
+        });
+      }
+      return "{}";
+    });
+    const verify = vi.fn(() => ({
+      valid: true,
+      readinessClass: "runtime_ready",
+      runtimeReady: true,
+      readinessSummary: "Ready to run.",
+      checks: [],
+      warnings: [],
+      runtimeReadinessIssues: [],
+      remediationSteps: [],
+      errors: [],
+    }));
+
+    vi.doMock("node:fs", () => ({
+      default: { existsSync, readFileSync },
+    }));
+    vi.doMock("../src/core/verifier.js", () => ({ verify }));
+    vi.doMock("../src/utils/output.js", () => ({ printVerifyResult: vi.fn() }));
+    vi.doMock("../src/core/adapters/openclaw.js", () => ({
+      openClawAdapter: { resolveStateDir: () => "/tmp/openclaw" },
+    }));
+
+    const { verifyCommand } = await importFresh<typeof import("../src/commands/verify.js")>("../src/commands/verify.js");
+    await verifyCommand.parseAsync(["node", "verify"], { from: "node" });
+
+    expect(verify).toHaveBeenCalledWith("/tmp/openclaw", undefined, expect.objectContaining({
+      image: { imageId: "child-compose", adapter: "openclaw" },
+    }));
   });
 
   it("verifies an explicit target path and falls back to the hidden manifest file", async () => {
@@ -589,7 +647,7 @@ describe("command entrypoints", () => {
     await verifyCommand.parseAsync(["node", "verify", "--path", "./fixture-state"], { from: "node" });
 
     expect(resolveStateDir).not.toHaveBeenCalled();
-    expect(verify).toHaveBeenCalledWith(expect.stringMatching(/fixture-state$/), { packId: "hidden-pack" });
+    expect(verify).toHaveBeenCalledWith(expect.stringMatching(/fixture-state$/), { packId: "hidden-pack" }, undefined);
     expect(printVerifyResult).toHaveBeenCalledWith(expect.objectContaining({
       readinessClass: "runtime_ready",
     }), "text");

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -306,6 +306,10 @@ describe("export + import", () => {
     expect(fs.readFileSync(path.join(outputDir, "workspace", "AGENTS.md"), "utf8")).toContain("Child Agent");
     expect(fs.existsSync(path.join(outputDir, "workspace", "SOUL.md"))).toBe(true);
     expect(fs.existsSync(path.join(outputDir, "credentials", "oauth.json"))).toBe(true);
+    expect(JSON.parse(fs.readFileSync(path.join(outputDir, "harness.definition.json"), "utf8")).lineage).toEqual({
+      parentImage: { refType: "image-id", value: "parent" },
+      layerOrder: ["parent", "child-agent"],
+    });
 
     const composedConfig = JSON.parse(fs.readFileSync(path.join(outputDir, "openclaw.json"), "utf8"));
     expect(composedConfig.agents.defaults.workspace).toBe(path.join(outputDir, "workspace"));
@@ -707,6 +711,71 @@ describe("export + import", () => {
     expect(verifyResult.checks.some(c => c.name === "manifest_image" && c.passed)).toBe(true);
     expect(verifyResult.checks.some(c => c.name === "binding_semantics" && c.passed)).toBe(true);
   });
+
+  it("exports a composed output using the source-path definition snapshot", async () => {
+    const parentDir = createMockInstance(path.join(tmpDir, "compose-export-parent"));
+    const childDir = createMockInstance(path.join(tmpDir, "compose-export-child"));
+    const repoDir = path.join(tmpDir, "compose-export-repo");
+    const composedDir = path.join(tmpDir, "compose-export-output");
+    const packFile = path.join(tmpDir, "compose-export.harness");
+
+    fs.mkdirSync(repoDir, { recursive: true });
+    fs.writeFileSync(path.join(repoDir, "harness.definition.json"), JSON.stringify({
+      schemaVersion: "0.2.0",
+      kind: "harness-definition",
+      image: { imageId: "child-compose", adapter: "openclaw" },
+      lineage: {
+        parentImage: { refType: "path", value: "../compose-export-parent" },
+        layerOrder: ["../compose-export-parent", "child-compose"],
+      },
+      harness: {
+        intent: "agent-runtime-environment",
+        targetProduct: "openclaw",
+        components: ["config", "workspace", "skills"],
+      },
+      bindings: {
+        workspaces: [
+          {
+            agentId: "main",
+            logicalPath: "workspace",
+            targetRelativePath: "workspace",
+            configTargets: ["agents.defaults.workspace", "agents.list[main].workspace"],
+            required: true,
+          },
+        ],
+      },
+      rebinding: {
+        workspaceTargetMode: "absolute-path",
+        mutableConfigTargets: ["agents.defaults.workspace", "agents.list[main].workspace"],
+      },
+      source: {
+        bootstrap: "starter",
+        detectedProduct: null,
+        configPath: null,
+      },
+      verify: {
+        readinessTarget: "runtime_ready",
+        expectedComponents: ["config", "workspace", "skills"],
+        requireWorkspaceBindings: true,
+      },
+    }, null, 2));
+
+    composeHarness({
+      cwd: repoDir,
+      sourcePath: childDir,
+      outputPath: composedDir,
+    });
+
+    const exportResult = await exportPack({
+      sourcePath: composedDir,
+      outputPath: packFile,
+      packType: "template",
+      cwd: tmpDir,
+    });
+
+    expect(exportResult.manifest.lineage.parentImage).toEqual({ imageId: "compose-export-parent" });
+    expect(exportResult.manifest.lineage.layerOrder).toEqual(["compose-export-parent", exportResult.manifest.image.imageId]);
+  });
 });
 
 describe("verify", () => {
@@ -719,6 +788,156 @@ describe("verify", () => {
     expect(result.readinessClass).toBe("runtime_ready");
     expect(result.remediationSteps).toEqual([]);
     expect(result.errors).toHaveLength(0);
+  });
+
+  it("reports lineage-aware success for a composed local result with a definition snapshot", () => {
+    const dir = createMockInstance(path.join(tmpDir, "verify-composed"));
+    fs.writeFileSync(path.join(dir, "harness.definition.json"), JSON.stringify({
+      schemaVersion: "0.2.0",
+      kind: "harness-definition",
+      image: { imageId: "child-compose", adapter: "openclaw" },
+      lineage: {
+        parentImage: { refType: "image-id", value: "base-compose" },
+        layerOrder: ["base-compose", "child-compose"],
+      },
+      harness: {
+        intent: "agent-runtime-environment",
+        targetProduct: "openclaw",
+        components: ["config", "workspace", "skills"],
+      },
+      bindings: {
+        workspaces: [
+          {
+            agentId: "main",
+            logicalPath: "workspace",
+            targetRelativePath: "workspace",
+            configTargets: ["agents.defaults.workspace", "agents.list[main].workspace"],
+            required: true,
+          },
+        ],
+      },
+      rebinding: {
+        workspaceTargetMode: "absolute-path",
+        mutableConfigTargets: ["agents.defaults.workspace", "agents.list[main].workspace"],
+      },
+      source: {
+        bootstrap: "starter",
+        detectedProduct: null,
+        configPath: null,
+      },
+      verify: {
+        readinessTarget: "runtime_ready",
+        expectedComponents: ["config", "workspace", "skills"],
+        requireWorkspaceBindings: true,
+      },
+    }, null, 2));
+
+    const definition = JSON.parse(fs.readFileSync(path.join(dir, "harness.definition.json"), "utf8"));
+    const result = verify(dir, undefined, definition);
+
+    expect(result.valid).toBe(true);
+    expect(result.readinessClass).toBe("runtime_ready");
+    expect(result.checks.some((check) => check.name === "lineage_declaration" && check.passed)).toBe(true);
+    expect(result.checks.some((check) => check.name === "lineage_materialization" && check.passed)).toBe(true);
+  });
+
+  it("distinguishes lineage materialization failures from declaration failures", () => {
+    const dir = createMockInstance(path.join(tmpDir, "verify-lineage-missing-skills"));
+    fs.rmSync(path.join(dir, "workspace", "skills"), { recursive: true, force: true });
+    const definition = {
+      schemaVersion: "0.2.0",
+      kind: "harness-definition",
+      image: { imageId: "child-compose", adapter: "openclaw" },
+      lineage: {
+        parentImage: { refType: "image-id", value: "base-compose" },
+        layerOrder: ["base-compose", "child-compose"],
+      },
+      harness: {
+        intent: "agent-runtime-environment",
+        targetProduct: "openclaw",
+        components: ["config", "workspace", "skills"],
+      },
+      bindings: {
+        workspaces: [
+          {
+            agentId: "main",
+            logicalPath: "workspace",
+            targetRelativePath: "workspace",
+            configTargets: ["agents.defaults.workspace", "agents.list[main].workspace"],
+            required: true,
+          },
+        ],
+      },
+      rebinding: {
+        workspaceTargetMode: "absolute-path",
+        mutableConfigTargets: ["agents.defaults.workspace", "agents.list[main].workspace"],
+      },
+      source: {
+        bootstrap: "starter",
+        detectedProduct: null,
+        configPath: null,
+      },
+      verify: {
+        readinessTarget: "runtime_ready",
+        expectedComponents: ["config", "workspace", "skills"],
+        requireWorkspaceBindings: true,
+      },
+    };
+
+    const result = verify(dir, undefined, definition);
+    expect(result.valid).toBe(true);
+    expect(result.readinessClass).toBe("manual_steps_required");
+    expect(result.checks.some((check) => check.name === "lineage_declaration" && check.passed)).toBe(true);
+    expect(result.checks.some((check) => check.name === "lineage_materialization" && !check.passed)).toBe(true);
+    expect(result.runtimeReadinessIssues).toContain("Lineage materialization missing expected component: skills");
+  });
+
+  it("fails verification when lineage declaration metadata is inconsistent", () => {
+    const dir = createMockInstance(path.join(tmpDir, "verify-lineage-invalid"));
+    const definition = {
+      schemaVersion: "0.2.0",
+      kind: "harness-definition",
+      image: { imageId: "child-compose", adapter: "openclaw" },
+      lineage: {
+        parentImage: { refType: "image-id", value: "base-compose" },
+        layerOrder: ["wrong-parent", "child-compose"],
+      },
+      harness: {
+        intent: "agent-runtime-environment",
+        targetProduct: "openclaw",
+        components: ["config", "workspace", "skills"],
+      },
+      bindings: {
+        workspaces: [
+          {
+            agentId: "main",
+            logicalPath: "workspace",
+            targetRelativePath: "workspace",
+            configTargets: ["agents.defaults.workspace", "agents.list[main].workspace"],
+            required: true,
+          },
+        ],
+      },
+      rebinding: {
+        workspaceTargetMode: "absolute-path",
+        mutableConfigTargets: ["agents.defaults.workspace", "agents.list[main].workspace"],
+      },
+      source: {
+        bootstrap: "starter",
+        detectedProduct: null,
+        configPath: null,
+      },
+      verify: {
+        readinessTarget: "runtime_ready",
+        expectedComponents: ["config", "workspace", "skills"],
+        requireWorkspaceBindings: true,
+      },
+    };
+
+    const result = verify(dir, undefined, definition);
+    expect(result.valid).toBe(false);
+    expect(result.readinessClass).toBe("structurally_invalid");
+    expect(result.checks.some((check) => check.name === "definition_contract" && !check.passed)).toBe(true);
   });
 
   it("fails for non-existent directory", () => {


### PR DESCRIPTION
Closes #109

Extend the existing export/import/verify lifecycle so it understands the first composed-image semantics introduced in v0.2.0.

Implementation notes:
- compose now persists a resolved `harness.definition.json` snapshot into the materialized output so later lifecycle steps can recover lineage semantics without the original repo-relative parent path
- export now auto-discovers a definition snapshot from the source path when no explicit or cwd definition is present
- verify now consumes optional definition metadata in addition to pack manifests and reports `definition_contract`, `lineage_declaration`, and `lineage_materialization` checks
- added regression coverage for composed export discovery, lineage-aware verify success, lineage materialization failure, and invalid lineage declaration handling

Validation:
- `npm run build`
- `npm test`
- `./scripts/run-cli-smoke.sh`
- `npm test`