### PR TITLE
Refactor builder and materialization boundaries for definition-driven v0.2.0 flows

### DIFF
--- a/.codex/pm/issue-state/108-refactor-builder-and-materialization-boundaries-for-definition-driven-v0-2-0-flows.md
+++ b/.codex/pm/issue-state/108-refactor-builder-and-materialization-boundaries-for-definition-driven-v0-2-0-flows.md
@@ -4,7 +4,8 @@ issue: 108
 task: .codex/pm/tasks/product-direction/refactor-builder-and-materialization-boundaries-for-definition-driven-v0-2-0-flows.md
 title: Refactor builder and materialization boundaries for definition-driven v0.2.0 flows
 status: done
-delivery_stage: ready_to_deliver
+delivery_stage: pr_opened
+pr_url: https://github.com/HarnessHub/HarnessHub/pull/117
 ---
 
 ## Summary

--- a/.codex/pm/issue-state/108-refactor-builder-and-materialization-boundaries-for-definition-driven-v0-2-0-flows.md
+++ b/.codex/pm/issue-state/108-refactor-builder-and-materialization-boundaries-for-definition-driven-v0-2-0-flows.md
@@ -1,0 +1,39 @@
+---
+type: issue_state
+issue: 108
+task: .codex/pm/tasks/product-direction/refactor-builder-and-materialization-boundaries-for-definition-driven-v0-2-0-flows.md
+title: Refactor builder and materialization boundaries for definition-driven v0.2.0 flows
+status: in_progress
+delivery_stage: implementing
+---
+
+## Summary
+
+Restructure the current internals so definition-driven and composed-image flows do not overload the v0.1.x snapshot path.
+
+## Validated Facts
+
+- definition/composition code paths are not hidden inside OpenClaw-only logic
+- builder/materializer responsibilities are clearer in code structure
+- the refactor does not regress the v0.1.x lifecycle
+- tests keep existing OpenClaw packaging behavior intact while covering the new seams
+- image, lineage, binding, and placement builders now live in a shared core module instead of inside `packer.ts`
+- import restore and workspace rebinding now use shared materialization helpers instead of separate compose versus import implementations
+- the OpenClaw adapter still owns adapter-specific integration, but no longer owns the core rebinding implementation details
+
+## Open Questions
+
+-
+
+## Next Steps
+
+- commit, review-checkpoint, preflight, and deliver the branch
+- after merge, the split `0.2.0` implementation issues are complete
+
+## Artifacts
+
+- `src/core/builder.ts`
+- `src/core/materialization.ts`
+- `src/core/packer.ts`
+- `src/core/compose.ts`
+- `src/core/adapters/openclaw.ts`

--- a/.codex/pm/issue-state/108-refactor-builder-and-materialization-boundaries-for-definition-driven-v0-2-0-flows.md
+++ b/.codex/pm/issue-state/108-refactor-builder-and-materialization-boundaries-for-definition-driven-v0-2-0-flows.md
@@ -3,8 +3,8 @@ type: issue_state
 issue: 108
 task: .codex/pm/tasks/product-direction/refactor-builder-and-materialization-boundaries-for-definition-driven-v0-2-0-flows.md
 title: Refactor builder and materialization boundaries for definition-driven v0.2.0 flows
-status: in_progress
-delivery_stage: implementing
+status: done
+delivery_stage: ready_to_deliver
 ---
 
 ## Summary

--- a/.codex/pm/tasks/product-direction/refactor-builder-and-materialization-boundaries-for-definition-driven-v0-2-0-flows.md
+++ b/.codex/pm/tasks/product-direction/refactor-builder-and-materialization-boundaries-for-definition-driven-v0-2-0-flows.md
@@ -1,0 +1,44 @@
+---
+type: task
+epic: product-direction
+slug: refactor-builder-and-materialization-boundaries-for-definition-driven-v0-2-0-flows
+title: Refactor builder and materialization boundaries for definition-driven v0.2.0 flows
+status: in_progress
+task_type: implementation
+issue: 108
+state_path: .codex/pm/issue-state/108-refactor-builder-and-materialization-boundaries-for-definition-driven-v0-2-0-flows.md
+---
+
+## Context
+
+Restructure the current internals so definition-driven and composed-image flows do not overload the v0.1.x snapshot path.
+
+## Deliverable
+
+Restructure the current internals so definition-driven and composed-image flows do not overload the v0.1.x snapshot path.
+
+## Scope
+
+- separate definition/composition concerns from adapter-specific snapshot inspection
+- make builder, materializer, and verifier boundaries clearer for v0.2.0
+- preserve current OpenClaw-first behavior while reducing internal coupling
+
+## Acceptance Criteria
+
+- definition/composition code paths are not hidden inside OpenClaw-only logic
+- builder/materializer responsibilities are clearer in code structure
+- the refactor does not regress the v0.1.x lifecycle
+- tests keep existing OpenClaw packaging behavior intact while covering the new seams
+
+## Validation
+
+- `npm run build`
+- `npm test`
+- `./scripts/run-cli-smoke.sh`
+
+## Implementation Notes
+
+- added `src/core/builder.ts` to hold shared image/lineage/binding/placement contract builders that were previously embedded inside `packer.ts`
+- added `src/core/materialization.ts` to hold shared restore and workspace-rebinding helpers used by import, compose, and the OpenClaw adapter
+- updated `packer.ts`, `compose.ts`, and `adapters/openclaw.ts` to consume the shared seams instead of keeping duplicate low-level materialization logic
+- preserved the existing OpenClaw-first lifecycle and verification behavior while making definition-driven and composed flows depend on explicit shared modules

--- a/.codex/pm/tasks/product-direction/refactor-builder-and-materialization-boundaries-for-definition-driven-v0-2-0-flows.md
+++ b/.codex/pm/tasks/product-direction/refactor-builder-and-materialization-boundaries-for-definition-driven-v0-2-0-flows.md
@@ -3,7 +3,7 @@ type: task
 epic: product-direction
 slug: refactor-builder-and-materialization-boundaries-for-definition-driven-v0-2-0-flows
 title: Refactor builder and materialization boundaries for definition-driven v0.2.0 flows
-status: in_progress
+status: done
 task_type: implementation
 issue: 108
 state_path: .codex/pm/issue-state/108-refactor-builder-and-materialization-boundaries-for-definition-driven-v0-2-0-flows.md

--- a/src/core/adapters/openclaw.ts
+++ b/src/core/adapters/openclaw.ts
@@ -1,5 +1,3 @@
-import fs from "node:fs";
-import JSON5 from "json5";
 import type { Manifest } from "../types.js";
 import {
   findConfigFile,
@@ -7,61 +5,17 @@ import {
   resolveStateDir,
   resolveWorkspaceBindings,
 } from "../scanner.js";
+import { rebindWorkspaceTargets } from "../materialization.js";
 import type { HarnessAdapter } from "./types.js";
 
 function rebindImportedConfig(targetDir: string, manifest: Manifest, warnings: string[]) {
   const configPath = findConfigFile(targetDir);
-  const workspaceBindings = manifest.bindings?.workspaces ?? [];
-  const mutableTargets = new Set(manifest.rebinding?.mutableConfigTargets ?? []);
-  if (!configPath || workspaceBindings.length === 0) return;
-
-  let parsed: any;
-  try {
-    parsed = JSON5.parse(fs.readFileSync(configPath, "utf-8"));
-  } catch {
-    warnings.push(`Could not parse config for workspace rebinding: ${configPath.split("/").pop()}`);
-    return;
-  }
-
-  if (!parsed || typeof parsed !== "object") return;
-
-  if (!parsed.agents || typeof parsed.agents !== "object") {
-    parsed.agents = {};
-  }
-  if (!parsed.agents.defaults || typeof parsed.agents.defaults !== "object") {
-    parsed.agents.defaults = {};
-  }
-  if (!Array.isArray(parsed.agents.list)) {
-    parsed.agents.list = [];
-  }
-
-  let changed = false;
-
-  for (const workspace of workspaceBindings) {
-    const targetWorkspacePath = `${targetDir}/${workspace.targetRelativePath}`;
-    const isDefault = workspace.targetRelativePath === "workspace";
-
-    if (isDefault && mutableTargets.has("agents.defaults.workspace") && parsed.agents.defaults.workspace !== targetWorkspacePath) {
-      parsed.agents.defaults.workspace = targetWorkspacePath;
-      changed = true;
-    }
-
-    const agentEntry = parsed.agents.list.find((entry: any) => {
-      const id = typeof entry?.id === "string" ? entry.id.trim().toLowerCase() : "";
-      return id === workspace.agentId;
-    });
-    if (agentEntry && mutableTargets.has(`agents.list[${workspace.agentId}].workspace`) && agentEntry.workspace !== targetWorkspacePath) {
-      agentEntry.workspace = targetWorkspacePath;
-      changed = true;
-    }
-  }
-
-  if (!changed) return;
-
-  fs.writeFileSync(configPath, `${JSON.stringify(parsed, null, 2)}\n`);
-  warnings.push(
-    `Rebound workspace paths in ${configPath.split("/").pop()} to ${targetDir}; JSON5 formatting/comments were normalized.`
-  );
+  warnings.push(...rebindWorkspaceTargets({
+    targetDir,
+    configPath,
+    bindings: manifest.bindings?.workspaces ?? [],
+    mutableTargets: manifest.rebinding?.mutableConfigTargets ?? [],
+  }));
 }
 
 export const openClawAdapter: HarnessAdapter = {

--- a/src/core/builder.ts
+++ b/src/core/builder.ts
@@ -1,0 +1,85 @@
+import type {
+  BindingSemantics,
+  HarnessAdapterId,
+  HarnessImageLineage,
+  HarnessImageMetadata,
+  PlacementContract,
+  RebindingContract,
+  WorkspaceBinding,
+  WorkspaceBindingRule,
+} from "./types.js";
+
+export const DEFAULT_COMPONENT_ROOTS = {
+  config: "config",
+  workspace: "workspace",
+  workspaces: "workspaces",
+  reports: "reports",
+  state: "state",
+} as const;
+
+const DEFAULT_PERSISTED_MANIFEST_PATH = ".harness-manifest.json";
+
+export function createImageMetadata(packId: string, adapter: HarnessAdapterId): HarnessImageMetadata {
+  return {
+    imageId: packId,
+    adapter,
+  };
+}
+
+export function createInitialLineage(): HarnessImageLineage {
+  return {
+    parentImage: null,
+    layerOrder: [],
+  };
+}
+
+export function createResolvedLineage(
+  packId: string,
+  parentImage: HarnessImageLineage["parentImage"]
+): HarnessImageLineage {
+  if (parentImage === null) {
+    return createInitialLineage();
+  }
+
+  return {
+    parentImage,
+    layerOrder: [parentImage.imageId, packId],
+  };
+}
+
+export function createBindingSemantics(workspaces: readonly WorkspaceBinding[]): BindingSemantics {
+  const workspaceRules: WorkspaceBindingRule[] = workspaces.map((workspace) => ({
+    agentId: workspace.agentId,
+    logicalPath: workspace.logicalPath,
+    targetRelativePath: workspace.isDefault ? "workspace" : workspace.logicalPath,
+    configTargets: workspace.isDefault
+      ? ["agents.defaults.workspace", `agents.list[${workspace.agentId}].workspace`]
+      : [`agents.list[${workspace.agentId}].workspace`],
+    required: true,
+  }));
+
+  return {
+    workspaces: workspaceRules,
+  };
+}
+
+export function createPlacementContract(): PlacementContract {
+  return {
+    reservedRoots: [
+      DEFAULT_COMPONENT_ROOTS.config,
+      DEFAULT_COMPONENT_ROOTS.workspace,
+      DEFAULT_COMPONENT_ROOTS.workspaces,
+      DEFAULT_COMPONENT_ROOTS.reports,
+      DEFAULT_COMPONENT_ROOTS.state,
+    ],
+    componentRoots: { ...DEFAULT_COMPONENT_ROOTS },
+    persistedManifestPath: DEFAULT_PERSISTED_MANIFEST_PATH,
+  };
+}
+
+export function createRebindingContract(bindings: BindingSemantics): RebindingContract {
+  return {
+    workspaceTargetMode: "absolute-path",
+    mutableConfigTargets: [...new Set(bindings.workspaces.flatMap((binding) => binding.configTargets))],
+  };
+}

--- a/src/core/compose.ts
+++ b/src/core/compose.ts
@@ -1,8 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
-import JSON5 from "json5";
 import { openClawAdapter } from "./adapters/openclaw.js";
+import { createBindingSemantics } from "./builder.js";
 import { readHarnessDefinition, validateOperationalDefinitionLineage } from "./definition.js";
+import { rebindWorkspaceTargets } from "./materialization.js";
 import {
   HARNESS_DEFINITION_FILE,
   HARNESS_DEFINITION_SCHEMA_VERSION,
@@ -340,52 +341,9 @@ function intersectSets(left: Set<string>, right: Set<string>): string[] {
 }
 
 function rebindComposedConfig(targetDir: string, workspaceBindings: readonly WorkspaceBinding[]): string[] {
-  const configPath = openClawAdapter.findConfigFile(targetDir);
-  if (!configPath || workspaceBindings.length === 0) return [];
-
-  let parsed: any;
-  try {
-    parsed = JSON5.parse(fs.readFileSync(configPath, "utf8"));
-  } catch {
-    return [`Could not parse config for workspace rebinding: ${path.basename(configPath)}`];
-  }
-
-  if (!parsed || typeof parsed !== "object") {
-    return [];
-  }
-
-  if (!parsed.agents || typeof parsed.agents !== "object") {
-    parsed.agents = {};
-  }
-  if (!parsed.agents.defaults || typeof parsed.agents.defaults !== "object") {
-    parsed.agents.defaults = {};
-  }
-  if (!Array.isArray(parsed.agents.list)) {
-    parsed.agents.list = [];
-  }
-
-  let changed = false;
-  for (const workspace of workspaceBindings) {
-    const targetWorkspacePath = path.join(targetDir, workspace.isDefault ? "workspace" : workspace.logicalPath);
-    if (workspace.isDefault && parsed.agents.defaults.workspace !== targetWorkspacePath) {
-      parsed.agents.defaults.workspace = targetWorkspacePath;
-      changed = true;
-    }
-
-    const agentEntry = parsed.agents.list.find((entry: any) => {
-      const id = typeof entry?.id === "string" ? entry.id.trim().toLowerCase() : "";
-      return id === workspace.agentId;
-    });
-    if (agentEntry && agentEntry.workspace !== targetWorkspacePath) {
-      agentEntry.workspace = targetWorkspacePath;
-      changed = true;
-    }
-  }
-
-  if (!changed) return [];
-
-  fs.writeFileSync(configPath, `${JSON.stringify(parsed, null, 2)}\n`);
-  return [
-    `Rebound workspace paths in ${path.basename(configPath)} to ${targetDir}; JSON5 formatting/comments were normalized.`,
-  ];
+  return rebindWorkspaceTargets({
+    targetDir,
+    configPath: openClawAdapter.findConfigFile(targetDir),
+    bindings: createBindingSemantics(workspaceBindings).workspaces,
+  });
 }

--- a/src/core/materialization.ts
+++ b/src/core/materialization.ts
@@ -1,0 +1,141 @@
+import fs from "node:fs";
+import path from "node:path";
+import JSON5 from "json5";
+import type { BindingSemantics, Manifest } from "./types.js";
+
+export function copyDirRecursive(src: string, dest: string) {
+  fs.mkdirSync(dest, { recursive: true });
+  const entries = fs.readdirSync(src, { withFileTypes: true });
+  for (const entry of entries) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyDirRecursive(srcPath, destPath);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
+export function restoreImportedMaterialization(tempDir: string, targetDir: string, manifest: Manifest) {
+  const wsSource = path.join(tempDir, manifest.placement.componentRoots.workspace);
+  if (fs.existsSync(wsSource)) {
+    copyDirRecursive(wsSource, path.join(targetDir, manifest.placement.componentRoots.workspace));
+  }
+
+  const workspacesSource = path.join(tempDir, manifest.placement.componentRoots.workspaces);
+  if (fs.existsSync(workspacesSource)) {
+    restoreAgentWorkspaces(workspacesSource, targetDir);
+  }
+
+  const configSource = path.join(tempDir, manifest.placement.componentRoots.config);
+  if (fs.existsSync(configSource)) {
+    restoreConfigDir(configSource, targetDir);
+  }
+
+  const stateSource = path.join(tempDir, manifest.placement.componentRoots.state);
+  if (fs.existsSync(stateSource)) {
+    restoreStateDir(stateSource, targetDir);
+  }
+}
+
+export function rebindWorkspaceTargets(params: {
+  targetDir: string;
+  configPath: string | null;
+  bindings: BindingSemantics["workspaces"];
+  mutableTargets?: readonly string[];
+}): string[] {
+  const { targetDir, configPath, bindings, mutableTargets } = params;
+  if (!configPath || bindings.length === 0) return [];
+
+  let parsed: any;
+  try {
+    parsed = JSON5.parse(fs.readFileSync(configPath, "utf-8"));
+  } catch {
+    return [`Could not parse config for workspace rebinding: ${path.basename(configPath)}`];
+  }
+
+  if (!parsed || typeof parsed !== "object") return [];
+
+  if (!parsed.agents || typeof parsed.agents !== "object") {
+    parsed.agents = {};
+  }
+  if (!parsed.agents.defaults || typeof parsed.agents.defaults !== "object") {
+    parsed.agents.defaults = {};
+  }
+  if (!Array.isArray(parsed.agents.list)) {
+    parsed.agents.list = [];
+  }
+
+  const allowedTargets = new Set(mutableTargets ?? bindings.flatMap((binding) => binding.configTargets));
+  let changed = false;
+
+  for (const binding of bindings) {
+    const targetWorkspacePath = path.join(targetDir, binding.targetRelativePath);
+
+    if (
+      binding.targetRelativePath === "workspace"
+      && allowedTargets.has("agents.defaults.workspace")
+      && parsed.agents.defaults.workspace !== targetWorkspacePath
+    ) {
+      parsed.agents.defaults.workspace = targetWorkspacePath;
+      changed = true;
+    }
+
+    const agentEntry = parsed.agents.list.find((entry: any) => {
+      const id = typeof entry?.id === "string" ? entry.id.trim().toLowerCase() : "";
+      return id === binding.agentId;
+    });
+    if (!agentEntry) continue;
+
+    const agentTarget = `agents.list[${binding.agentId}].workspace`;
+    if (allowedTargets.has(agentTarget) && agentEntry.workspace !== targetWorkspacePath) {
+      agentEntry.workspace = targetWorkspacePath;
+      changed = true;
+    }
+  }
+
+  if (!changed) return [];
+
+  fs.writeFileSync(configPath, `${JSON.stringify(parsed, null, 2)}\n`);
+  return [
+    `Rebound workspace paths in ${path.basename(configPath)} to ${targetDir}; JSON5 formatting/comments were normalized.`,
+  ];
+}
+
+function restoreAgentWorkspaces(workspacesSource: string, targetDir: string) {
+  const entries = fs.readdirSync(workspacesSource, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    copyDirRecursive(
+      path.join(workspacesSource, entry.name),
+      path.join(targetDir, `workspace-${entry.name}`)
+    );
+  }
+}
+
+function restoreConfigDir(configSource: string, targetDir: string) {
+  const entries = fs.readdirSync(configSource, { withFileTypes: true });
+  for (const entry of entries) {
+    const src = path.join(configSource, entry.name);
+    if (entry.isDirectory()) {
+      copyDirRecursive(src, path.join(targetDir, entry.name));
+    } else {
+      fs.copyFileSync(src, path.join(targetDir, entry.name));
+    }
+  }
+}
+
+function restoreStateDir(stateSource: string, targetDir: string) {
+  const entries = fs.readdirSync(stateSource, { withFileTypes: true });
+  for (const entry of entries) {
+    const src = path.join(stateSource, entry.name);
+    const dest = path.join(targetDir, entry.name);
+    if (entry.isDirectory()) {
+      copyDirRecursive(src, dest);
+    } else {
+      fs.mkdirSync(path.dirname(dest), { recursive: true });
+      fs.copyFileSync(src, dest);
+    }
+  }
+}

--- a/src/core/packer.ts
+++ b/src/core/packer.ts
@@ -4,29 +4,33 @@ import crypto from "node:crypto";
 import * as tar from "tar";
 import JSON5 from "json5";
 import type {
-  HarnessAdapterId,
-  BindingSemantics,
   HarnessComponent,
-  HarnessMetadata,
   HarnessImageLineage,
-  HarnessImageMetadata,
+  HarnessMetadata,
   Manifest,
   PackType,
-  PlacementContract,
-  RebindingContract,
   RiskLevel,
   SensitiveFlags,
   WorkspaceBinding,
-  WorkspaceBindingRule,
 } from "./types.js";
 import { SCHEMA_VERSION } from "./types.js";
 import { openClawAdapter } from "./adapters/openclaw.js";
+import {
+  createBindingSemantics,
+  DEFAULT_COMPONENT_ROOTS,
+  createImageMetadata,
+  createInitialLineage,
+  createPlacementContract,
+  createRebindingContract,
+  createResolvedLineage,
+} from "./builder.js";
 import {
   readHarnessDefinition,
   readHarnessDefinitionIfPresent,
   resolveDefinitionParentImage,
   validateOperationalDefinitionLineage,
 } from "./definition.js";
+import { copyDirRecursive, restoreImportedMaterialization } from "./materialization.js";
 import { assertValidManifest } from "./manifest.js";
 import { isForbiddenInPackType, validatePackTypeComponents } from "./pack-contract.js";
 
@@ -69,83 +73,8 @@ const ALWAYS_EXCLUDE = [
   "*.bak.*",
 ];
 
-const DEFAULT_COMPONENT_ROOTS = {
-  config: "config",
-  workspace: "workspace",
-  workspaces: "workspaces",
-  reports: "reports",
-  state: "state",
-} as const;
-
-const DEFAULT_PERSISTED_MANIFEST_PATH = ".harness-manifest.json";
-
 function generatePackId(): string {
   return crypto.randomUUID();
-}
-
-function createImageMetadata(packId: string, adapter: HarnessAdapterId): HarnessImageMetadata {
-  return {
-    imageId: packId,
-    adapter,
-  };
-}
-
-function createInitialLineage(): HarnessImageLineage {
-  return {
-    parentImage: null,
-    layerOrder: [],
-  };
-}
-
-function createResolvedLineage(packId: string, parentImage: HarnessImageLineage["parentImage"]): HarnessImageLineage {
-  if (parentImage === null) {
-    return {
-      parentImage: null,
-      layerOrder: [],
-    };
-  }
-
-  return {
-    parentImage,
-    layerOrder: [parentImage.imageId, packId],
-  };
-}
-
-function createBindingSemantics(workspaces: readonly WorkspaceBinding[]): BindingSemantics {
-  const workspaceRules: WorkspaceBindingRule[] = workspaces.map((workspace) => ({
-    agentId: workspace.agentId,
-    logicalPath: workspace.logicalPath,
-    targetRelativePath: workspace.isDefault ? "workspace" : workspace.logicalPath,
-    configTargets: workspace.isDefault
-      ? ["agents.defaults.workspace", `agents.list[${workspace.agentId}].workspace`]
-      : [`agents.list[${workspace.agentId}].workspace`],
-    required: true,
-  }));
-
-  return {
-    workspaces: workspaceRules,
-  };
-}
-
-function createPlacementContract(): PlacementContract {
-  return {
-    reservedRoots: [
-      DEFAULT_COMPONENT_ROOTS.config,
-      DEFAULT_COMPONENT_ROOTS.workspace,
-      DEFAULT_COMPONENT_ROOTS.workspaces,
-      DEFAULT_COMPONENT_ROOTS.reports,
-      DEFAULT_COMPONENT_ROOTS.state,
-    ],
-    componentRoots: { ...DEFAULT_COMPONENT_ROOTS },
-    persistedManifestPath: DEFAULT_PERSISTED_MANIFEST_PATH,
-  };
-}
-
-function createRebindingContract(bindings: BindingSemantics): RebindingContract {
-  return {
-    workspaceTargetMode: "absolute-path",
-    mutableConfigTargets: [...new Set(bindings.workspaces.flatMap((binding) => binding.configTargets))],
-  };
 }
 
 function assessRisk(sensitive: SensitiveFlags, packType: PackType): RiskLevel {
@@ -626,28 +555,7 @@ export async function importPack(options: ImportOptions): Promise<ImportResult> 
 
     fs.mkdirSync(targetDir, { recursive: true });
 
-    // Restore workspace/ → workspace/
-    const wsSource = path.join(tempDir, manifest.placement.componentRoots.workspace);
-    if (fs.existsSync(wsSource)) {
-      copyDirRecursive(wsSource, path.join(targetDir, manifest.placement.componentRoots.workspace));
-    }
-
-    const workspacesSource = path.join(tempDir, manifest.placement.componentRoots.workspaces);
-    if (fs.existsSync(workspacesSource)) {
-      restoreAgentWorkspaces(workspacesSource, targetDir);
-    }
-
-    // Restore config/ → root level (config files go to stateDir root)
-    const configSource = path.join(tempDir, manifest.placement.componentRoots.config);
-    if (fs.existsSync(configSource)) {
-      restoreConfigDir(configSource, targetDir);
-    }
-
-    // Restore state/ → preserving nested structure
-    const stateSource = path.join(tempDir, manifest.placement.componentRoots.state);
-    if (fs.existsSync(stateSource)) {
-      restoreStateDir(stateSource, targetDir);
-    }
+    restoreImportedMaterialization(tempDir, targetDir, manifest);
 
     openClawAdapter.rebindImportedConfig(targetDir, manifest, warnings);
     fs.writeFileSync(
@@ -668,64 +576,5 @@ export async function importPack(options: ImportOptions): Promise<ImportResult> 
     return { targetDir, manifest, fileCount, warnings };
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
-  }
-}
-
-function restoreAgentWorkspaces(workspacesSource: string, targetDir: string) {
-  const entries = fs.readdirSync(workspacesSource, { withFileTypes: true });
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    copyDirRecursive(
-      path.join(workspacesSource, entry.name),
-      path.join(targetDir, `workspace-${entry.name}`)
-    );
-  }
-}
-
-/** Restore config directory: root-level configs go to stateDir root,
- *  subdirectories (hooks/, extensions/, etc.) preserve structure */
-function restoreConfigDir(configSource: string, targetDir: string) {
-  const entries = fs.readdirSync(configSource, { withFileTypes: true });
-  for (const entry of entries) {
-    const src = path.join(configSource, entry.name);
-    if (entry.isDirectory()) {
-      // Subdirectories like hooks/, extensions/ go to targetDir/<name>/
-      copyDirRecursive(src, path.join(targetDir, entry.name));
-    } else {
-      // Root config files go directly to targetDir/
-      fs.copyFileSync(src, path.join(targetDir, entry.name));
-    }
-  }
-}
-
-/** Restore state directory preserving nested structure:
- *  state/agents/<id>/... → agents/<id>/...
- *  state/credentials/... → credentials/...
- *  state/<file> → <file> */
-function restoreStateDir(stateSource: string, targetDir: string) {
-  const entries = fs.readdirSync(stateSource, { withFileTypes: true });
-  for (const entry of entries) {
-    const src = path.join(stateSource, entry.name);
-    const dest = path.join(targetDir, entry.name);
-    if (entry.isDirectory()) {
-      copyDirRecursive(src, dest);
-    } else {
-      fs.mkdirSync(path.dirname(dest), { recursive: true });
-      fs.copyFileSync(src, dest);
-    }
-  }
-}
-
-function copyDirRecursive(src: string, dest: string) {
-  fs.mkdirSync(dest, { recursive: true });
-  const entries = fs.readdirSync(src, { withFileTypes: true });
-  for (const entry of entries) {
-    const srcPath = path.join(src, entry.name);
-    const destPath = path.join(dest, entry.name);
-    if (entry.isDirectory()) {
-      copyDirRecursive(srcPath, destPath);
-    } else {
-      fs.copyFileSync(srcPath, destPath);
-    }
   }
 }


### PR DESCRIPTION
Closes #108

Restructure the current internals so definition-driven and composed-image flows do not overload the v0.1.x snapshot path.

Implementation notes:
- added `src/core/builder.ts` to hold shared image/lineage/binding/placement contract builders that were previously embedded inside `packer.ts`
- added `src/core/materialization.ts` to hold shared restore and workspace-rebinding helpers used by import, compose, and the OpenClaw adapter
- updated `packer.ts`, `compose.ts`, and `adapters/openclaw.ts` to consume the shared seams instead of keeping duplicate low-level materialization logic
- preserved the existing OpenClaw-first lifecycle and verification behavior while making definition-driven and composed flows depend on explicit shared modules

Validation:
- `npm run build`
- `npm test`
- `./scripts/run-cli-smoke.sh`
- `npm test`